### PR TITLE
docs: Format inline codes in docs to canonical format

### DIFF
--- a/website/docs/d/db_instances.html.markdown
+++ b/website/docs/d/db_instances.html.markdown
@@ -16,7 +16,7 @@ This data source provides a list of database instance resources according to the
 data "ucloud_db_instances" "example" {}
 
 output "first" {
-    value = data.ucloud_db_instances.example.db_instances[0].id
+  value = data.ucloud_db_instances.example.db_instances[0].id
 }
 ```
 

--- a/website/docs/d/disks.html.markdown
+++ b/website/docs/d/disks.html.markdown
@@ -16,7 +16,7 @@ This data source provides a list of Disk resources according to their Disk ID an
 data "ucloud_disks" "example" {}
 
 output "first" {
-    value = data.ucloud_disks.example.disks[0].id
+  value = data.ucloud_disks.example.disks[0].id
 }
 ```
 

--- a/website/docs/d/eips.html.markdown
+++ b/website/docs/d/eips.html.markdown
@@ -16,7 +16,7 @@ This data source provides a list of EIP resources (Elastic IP address) according
 data "ucloud_eips" "example" {}
 
 output "first" {
-    value = data.ucloud_eips.example.eips[0].ip_set[0].ip
+  value = data.ucloud_eips.example.eips[0].ip_set[0].ip
 }
 ```
 

--- a/website/docs/d/images.html.markdown
+++ b/website/docs/d/images.html.markdown
@@ -14,13 +14,13 @@ This data source providers a list of available image resources according to thei
 
 ```hcl
 data "ucloud_images" "example" {
-    availability_zone = "cn-bj2-02"
-    image_type = "base"
-    name_regex = "^CentOS 7.[1-2] 64"
+  availability_zone = "cn-bj2-02"
+  image_type        = "base"
+  name_regex        = "^CentOS 7.[1-2] 64"
 }
 
 output "first" {
-    value = data.ucloud_images.example.images[0].id
+  value = data.ucloud_images.example.images[0].id
 }
 ```
 

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -14,11 +14,11 @@ This data source providers a list of UHost instance resources according to their
 
 ```hcl
 data "ucloud_instances" "example" {
-    availability_zone = "cn-bj2-02"
+  availability_zone = "cn-bj2-02"
 }
 
 output "first" {
-    value = data.ucloud_instances.example.instances[0].id
+  value = data.ucloud_instances.example.instances[0].id
 }
 ```
 

--- a/website/docs/d/lb_attachments.html.markdown
+++ b/website/docs/d/lb_attachments.html.markdown
@@ -14,12 +14,12 @@ This data source provides a list of Load Balancer Attachment resources according
 
 ```hcl
 data "ucloud_lb_attachments" "example" {
-    load_balancer_id = "ulb-xxx"
-    listener_id = "vserver-xxx"
+  load_balancer_id = "ulb-xxx"
+  listener_id      = "vserver-xxx"
 }
 
 output "first" {
-    value = data.ucloud_lb_attachments.example.lb_attachments[0].id
+  value = data.ucloud_lb_attachments.example.lb_attachments[0].id
 }
 ```
 

--- a/website/docs/d/lb_listeners.html.markdown
+++ b/website/docs/d/lb_listeners.html.markdown
@@ -14,11 +14,11 @@ This data source provides a list of Load Balancer Listener resources according t
 
 ```hcl
 data "ucloud_lb_listeners" "example" {
-    load_balancer_id = "ulb-xxx"
+  load_balancer_id = "ulb-xxx"
 }
 
 output "first" {
-    value = data.ucloud_lb_listeners.example.lb_listeners[0].id
+  value = data.ucloud_lb_listeners.example.lb_listeners[0].id
 }
 ```
 

--- a/website/docs/d/lb_rules.html.markdown
+++ b/website/docs/d/lb_rules.html.markdown
@@ -14,12 +14,12 @@ This data source provides a list of Load Balancer Rule resources according to th
 
 ```hcl
 data "ucloud_lb_rules" "example" {
-    load_balancer_id = "ulb-xxx"
-    listener_id = "vserver-xxx"
+  load_balancer_id = "ulb-xxx"
+  listener_id      = "vserver-xxx"
 }
 
 output "first" {
-    value = data.ucloud_lb_rules.example.lb_rules[0].id
+  value = data.ucloud_lb_rules.example.lb_rules[0].id
 }
 ```
 

--- a/website/docs/d/lb_ssls.html.markdown
+++ b/website/docs/d/lb_ssls.html.markdown
@@ -17,7 +17,7 @@ data "ucloud_lb_ssls" "example" {
 }
 
 output "first" {
-    value = data.ucloud_lb_ssls.example.lb_ssls[0].id
+  value = data.ucloud_lb_ssls.example.lb_ssls[0].id
 }
 ```
 

--- a/website/docs/d/lbs.html.markdown
+++ b/website/docs/d/lbs.html.markdown
@@ -17,7 +17,7 @@ data "ucloud_lbs" "example" {
 }
 
 output "first" {
-    value = data.ucloud_lbs.example.lbs[0].id
+  value = data.ucloud_lbs.example.lbs[0].id
 }
 ```
 

--- a/website/docs/d/projects.html.markdown
+++ b/website/docs/d/projects.html.markdown
@@ -14,11 +14,11 @@ This data source providers a list of projects owned by user according to finance
 
 ```hcl
 data "ucloud_projects" "example" {
-    is_finance = false
+  is_finance = false
 }
 
 output "first" {
-    value = data.ucloud_projects.example.projects[0].id
+  value = data.ucloud_projects.example.projects[0].id
 }
 ```
 

--- a/website/docs/d/security_groups.html.markdown
+++ b/website/docs/d/security_groups.html.markdown
@@ -16,7 +16,7 @@ This data source provides a list of Security Group resources according to their 
 data "ucloud_security_groups" "example" {}
 
 output "first" {
-    value = data.ucloud_security_groups.example.security_groups[0].id
+  value = data.ucloud_security_groups.example.security_groups[0].id
 }
 ```
 

--- a/website/docs/d/subnets.html.markdown
+++ b/website/docs/d/subnets.html.markdown
@@ -14,11 +14,11 @@ This data source provides a list of Subnet resources according to their Subnet I
 
 ```hcl
 data "ucloud_subnets" "example" {
-    vpc_id  =  "uvnet-xxx"
+  vpc_id = "uvnet-xxx"
 }
 
 output "first" {
-    value = data.ucloud_subnets.example.subnets[0].id
+  value = data.ucloud_subnets.example.subnets[0].id
 }
 ```
 

--- a/website/docs/d/vpcs.html.markdown
+++ b/website/docs/d/vpcs.html.markdown
@@ -17,7 +17,7 @@ data "ucloud_vpcs" "example" {
 }
 
 output "first" {
-    value = data.ucloud_vpcs.example.vpcs[0].id
+  value = data.ucloud_vpcs.example.vpcs[0].id
 }
 ```
 

--- a/website/docs/d/zones.html.markdown
+++ b/website/docs/d/zones.html.markdown
@@ -16,7 +16,7 @@ This data source provides a list of available zones in the current region.
 data "ucloud_zones" "example" {}
 
 output "first" {
-    value = data.ucloud_zones.example.zones[0].id
+  value = data.ucloud_zones.example.zones[0].id
 }
 ```
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -29,7 +29,7 @@ provider "ucloud" {
 
 # Query default security group
 data "ucloud_security_groups" "default" {
-    type = "recommend_web"
+  type = "recommend_web"
 }
 
 # Query image
@@ -41,22 +41,22 @@ data "ucloud_images" "default" {
 
 # Create web instance 
 resource "ucloud_instance" "web" {
-    availability_zone = "cn-bj2-04"
-    image_id          = data.ucloud_images.default.images[0].id
-    instance_type     = "n-basic-2"
-    root_password     = "wA1234567"
-    name              = "tf-example-instance"
-    tag               = "tf-example"
+  availability_zone = "cn-bj2-04"
+  image_id          = data.ucloud_images.default.images[0].id
+  instance_type     = "n-basic-2"
+  root_password     = "wA1234567"
+  name              = "tf-example-instance"
+  tag               = "tf-example"
 
-    # the default Web Security Group that UCloud recommend to users
-    security_group = data.ucloud_security_groups.default.security_groups[0].id
+  # the default Web Security Group that UCloud recommend to users
+  security_group = data.ucloud_security_groups.default.security_groups[0].id
 }
 
 # Create cloud disk
 resource "ucloud_disk" "example" {
-    availability_zone = "cn-bj2-04"
-    name              = "tf-example-instance"
-    disk_size         = 30
+  availability_zone = "cn-bj2-04"
+  name              = "tf-example-instance"
+  disk_size         = 30
 }
 
 # Attach cloud disk to instance
@@ -85,10 +85,10 @@ Usage:
 
 ```hcl
 provider "ucloud" {
-  public_key = "your_public_key"
+  public_key  = "your_public_key"
   private_key = "your_private_key"
-  project_id = "your_project_id"
-  region     = "cn-bj2"
+  project_id  = "your_project_id"
+  region      = "cn-bj2"
 }
 ```
 

--- a/website/docs/r/disk.html.markdown
+++ b/website/docs/r/disk.html.markdown
@@ -18,9 +18,9 @@ data "ucloud_zones" "default" {}
 
 # Create cloud disk
 resource "ucloud_disk" "example" {
-    availability_zone = data.ucloud_zones.default.zones[0].id
-    name              = "tf-example-disk"
-    disk_size         = 10
+  availability_zone = data.ucloud_zones.default.zones[0].id
+  name              = "tf-example-disk"
+  disk_size         = 10
 }
 ```
 

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -14,11 +14,11 @@ Provides an Elastic IP resource.
 
 ```hcl
 resource "ucloud_eip" "example" {
-    bandwidth            = 2
-    charge_mode          = "bandwidth"
-    name                 = "tf-example-eip"
-    tag                  = "tf-example"
-    internet_type        = "bgp"
+  bandwidth     = 2
+  charge_mode   = "bandwidth"
+  name          = "tf-example-eip"
+  tag           = "tf-example"
+  internet_type = "bgp"
 }
 ```
 

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -61,8 +61,8 @@ resource "ucloud_instance" "web" {
 
 # Bind eip to instance
 resource "ucloud_eip_association" "default" {
-  resource_id   = ucloud_instance.web.id
-  eip_id        = ucloud_eip.default.id
+  resource_id = ucloud_instance.web.id
+  eip_id      = ucloud_eip.default.id
 }
 ```
 

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -17,7 +17,7 @@ Provides an UHost Instance resource.
 ```hcl
 # Query default security group
 data "ucloud_security_groups" "default" {
-    type = "recommend_web"
+  type = "recommend_web"
 }
 
 # Query image
@@ -29,22 +29,22 @@ data "ucloud_images" "default" {
 
 # Create web instance 
 resource "ucloud_instance" "web" {
-    availability_zone = "cn-bj2-04"
-    image_id          = data.ucloud_images.default.images[0].id
-    instance_type     = "n-basic-2"
-    root_password     = "wA1234567"
-    name              = "tf-example-instance"
-    tag               = "tf-example"
+  availability_zone = "cn-bj2-04"
+  image_id          = data.ucloud_images.default.images[0].id
+  instance_type     = "n-basic-2"
+  root_password     = "wA1234567"
+  name              = "tf-example-instance"
+  tag               = "tf-example"
 
-    # the default Web Security Group that UCloud recommend to users
-    security_group = data.ucloud_security_groups.default.security_groups[0].id
+  # the default Web Security Group that UCloud recommend to users
+  security_group = data.ucloud_security_groups.default.security_groups[0].id
 }
 
 # Create cloud disk
 resource "ucloud_disk" "example" {
-    availability_zone = "cn-bj2-04"
-    name              = "tf-example-instance"
-    disk_size         = 30
+  availability_zone = "cn-bj2-04"
+  name              = "tf-example-instance"
+  disk_size         = 30
 }
 
 # Attach cloud disk to instance

--- a/website/docs/r/isolation_group.html.markdown
+++ b/website/docs/r/isolation_group.html.markdown
@@ -14,8 +14,8 @@ Provides an Isolation Group resource. The Isolation Group is a logical group of 
 
 ```hcl
 resource "ucloud_isolation_group" "foo" {
-	name  = "tf-acc-isolation-group"
-	remark = "test"
+  name   = "tf-acc-isolation-group"
+  remark = "test"
 }
 ```
 

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -14,8 +14,8 @@ Provides a Load Balancer resource.
 
 ```hcl
 resource "ucloud_lb" "web" {
-    name = "tf-example-lb"
-    tag  = "tf-example"
+  name = "tf-example-lb"
+  tag  = "tf-example"
 }
 ```
 

--- a/website/docs/r/lb_attachment.html.markdown
+++ b/website/docs/r/lb_attachment.html.markdown
@@ -22,34 +22,34 @@ data "ucloud_images" "default" {
 
 # Create Load Balancer
 resource "ucloud_lb" "web" {
-    name = "tf-example-lb"
-    tag  = "tf-example"
+  name = "tf-example-lb"
+  tag  = "tf-example"
 }
 
 # Create Load Balancer Listener with http protocol
 resource "ucloud_lb_listener" "default" {
-    load_balancer_id = ucloud_lb.web.id
-    protocol         = "http"
+  load_balancer_id = ucloud_lb.web.id
+  protocol         = "http"
 }
 
 # Create web server
 resource "ucloud_instance" "web" {
-    instance_type     = "n-basic-2"
-    availability_zone = "cn-bj2-04"
+  instance_type     = "n-basic-2"
+  availability_zone = "cn-bj2-04"
 
-    root_password     = "wA1234567"
-    image_id          = data.ucloud_images.default.images[0].id
+  root_password = "wA1234567"
+  image_id      = data.ucloud_images.default.images[0].id
 
-    name              = "tf-example-lb"
-    tag               = "tf-example"
+  name = "tf-example-lb"
+  tag  = "tf-example"
 }
 
 # Attach instances to Load Balancer
 resource "ucloud_lb_attachment" "example" {
-    load_balancer_id = ucloud_lb.web.id
-    listener_id      = ucloud_lb_listener.default.id
-    resource_id      = ucloud_instance.web.id
-    port             = 80
+  load_balancer_id = ucloud_lb.web.id
+  listener_id      = ucloud_lb_listener.default.id
+  resource_id      = ucloud_instance.web.id
+  port             = 80
 }
 ```
 

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -16,13 +16,13 @@ Provides a Load Balancer Listener resource.
 
 ```hcl
 resource "ucloud_lb" "web" {
-    name = "tf-example-lb"
-    tag  = "tf-example"
+  name = "tf-example-lb"
+  tag  = "tf-example"
 }
 
 resource "ucloud_lb_listener" "example" {
-    load_balancer_id = ucloud_lb.web.id
-    protocol         = "http"
+  load_balancer_id = ucloud_lb.web.id
+  protocol         = "http"
 }
 ```
 

--- a/website/docs/r/lb_rule.html.markdown
+++ b/website/docs/r/lb_rule.html.markdown
@@ -20,39 +20,39 @@ data "ucloud_images" "default" {
 }
 
 resource "ucloud_lb" "web" {
-    name = "tf-example-lb"
-    tag  = "tf-example"
+  name = "tf-example-lb"
+  tag  = "tf-example"
 }
 
 resource "ucloud_lb_listener" "default" {
-    load_balancer_id = ucloud_lb.web.id
-    protocol         = "http"
+  load_balancer_id = ucloud_lb.web.id
+  protocol         = "http"
 }
 
 resource "ucloud_instance" "web" {
-    instance_type     = "n-basic-2"
-    availability_zone = "cn-bj2-02"
+  instance_type     = "n-basic-2"
+  availability_zone = "cn-bj2-02"
 
-    root_password     = "wA1234567"
-    image_id          = data.ucloud_images.default.images[0].id
+  root_password = "wA1234567"
+  image_id      = data.ucloud_images.default.images[0].id
 
-    name              = "tf-example-lb"
-    tag               = "tf-example"
+  name = "tf-example-lb"
+  tag  = "tf-example"
 }
 
 resource "ucloud_lb_attachment" "default" {
-    load_balancer_id = ucloud_lb.web.id
-    listener_id      = ucloud_lb_listener.default.id
-    resource_type    = "instance"
-    resource_id      = ucloud_instance.web.id
-    port             = 80
+  load_balancer_id = ucloud_lb.web.id
+  listener_id      = ucloud_lb_listener.default.id
+  resource_type    = "instance"
+  resource_id      = ucloud_instance.web.id
+  port             = 80
 }
 
 resource "ucloud_lb_rule" "example" {
-    load_balancer_id = ucloud_lb.web.id
-    listener_id      = ucloud_lb_listener.default.id
-    backend_ids      = ucloud_lb_attachment.default.*.id
-    domain           = "www.ucloud.cn"
+  load_balancer_id = ucloud_lb.web.id
+  listener_id      = ucloud_lb_listener.default.id
+  backend_ids      = ucloud_lb_attachment.default.*.id
+  domain           = "www.ucloud.cn"
 }
 ```
 

--- a/website/docs/r/lb_ssl_attachment.html.markdown
+++ b/website/docs/r/lb_ssl_attachment.html.markdown
@@ -14,14 +14,14 @@ Provides a Load Balancer SSL attachment resource for attaching SSL certificate t
 
 ```hcl
 resource "ucloud_lb" "foo" {
-    name = "tf-example-lb-ssl-attachment"
-    tag  = "tf-example"
+  name = "tf-example-lb-ssl-attachment"
+  tag  = "tf-example"
 }
 
 resource "ucloud_lb_listener" "foo" {
-    name             = "tf-example-lb-ssl-attachment"
-    load_balancer_id = ucloud_lb.foo.id
-    protocol         = "https"
+  name             = "tf-example-lb-ssl-attachment"
+  load_balancer_id = ucloud_lb.foo.id
+  protocol         = "https"
 }
 
 resource "ucloud_lb_ssl" "foo" {
@@ -33,9 +33,9 @@ resource "ucloud_lb_ssl" "foo" {
 
 
 resource "ucloud_lb_ssl_attachment" "foo" {
-    load_balancer_id = ucloud_lb.foo.id
-    listener_id      = ucloud_lb_listener.foo.id
-    ssl_id      = ucloud_lb_ssl.foo.id
+  load_balancer_id = ucloud_lb.foo.id
+  listener_id      = ucloud_lb_listener.foo.id
+  ssl_id           = ucloud_lb_ssl.foo.id
 }
 ```
 

--- a/website/docs/r/memcache_instance.markdown
+++ b/website/docs/r/memcache_instance.markdown
@@ -19,8 +19,8 @@ resource "ucloud_memcache_instance" "master" {
   availability_zone = data.ucloud_zones.default.zones[0].id
   instance_type     = "memcache-master-2"
 
-  name              = "tf-example-memcache"
-  tag               = "tf-example"
+  name = "tf-example-memcache"
+  tag  = "tf-example"
 }
 ```
 

--- a/website/docs/r/redis_instance.markdown
+++ b/website/docs/r/redis_instance.markdown
@@ -21,16 +21,16 @@ resource "ucloud_redis_instance" "master" {
   password          = "2018_Tfacc"
   engine_version    = "4.0"
 
-  name              = "tf-example-redis-master"
-  tag               = "tf-example"
+  name = "tf-example-redis-master"
+  tag  = "tf-example"
 }
 
 resource "ucloud_redis_instance" "distributed" {
   availability_zone = data.ucloud_zones.default.zones[0].id
   instance_type     = "redis-distributed-16"
 
-  name              = "tf-example-redis-distributed"
-  tag               = "tf-example"
+  name = "tf-example-redis-distributed"
+  tag  = "tf-example"
 }
 ```
 

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -14,24 +14,24 @@ Provides a Security Group resource.
 
 ```hcl
 resource "ucloud_security_group" "example" {
-    name = "tf-example-security-group"
-    tag  = "tf-example"
+  name = "tf-example-security-group"
+  tag  = "tf-example"
 
-    # http access from LAN
-    rules {
-        port_range = "80"
-        protocol   = "tcp"
-        cidr_block = "192.168.0.0/16"
-        policy     = "accept"
-    }
+  # http access from LAN
+  rules {
+    port_range = "80"
+    protocol   = "tcp"
+    cidr_block = "192.168.0.0/16"
+    policy     = "accept"
+  }
 
-    # https access from LAN
-    rules {
-        port_range = "443"
-        protocol   = "tcp"
-        cidr_block = "192.168.0.0/16"
-        policy     = "accept"
-    }
+  # https access from LAN
+  rules {
+    port_range = "443"
+    protocol   = "tcp"
+    cidr_block = "192.168.0.0/16"
+    policy     = "accept"
+  }
 }
 ```
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -14,21 +14,21 @@ Provides a Subnet resource under VPC resource.
 
 ```hcl
 resource "ucloud_vpc" "default" {
-    name = "tf-example-vpc"
-    tag  = "tf-example"
+  name = "tf-example-vpc"
+  tag  = "tf-example"
 
-    # vpc network
-    cidr_blocks = ["192.168.0.0/16"]
+  # vpc network
+  cidr_blocks = ["192.168.0.0/16"]
 }
 
 resource "ucloud_subnet" "example" {
-    name = "tf-example-subnet"
-    tag  = "tf-example"
+  name = "tf-example-subnet"
+  tag  = "tf-example"
 
-    # subnet's network must be contained by vpc network
-    # and a subnet must have least 8 ip addresses in it (netmask < 30).
-    cidr_block = "192.168.1.0/24"
-    vpc_id     = ucloud_vpc.default.ids
+  # subnet's network must be contained by vpc network
+  # and a subnet must have least 8 ip addresses in it (netmask < 30).
+  cidr_block = "192.168.1.0/24"
+  vpc_id     = ucloud_vpc.default.ids
 }
 ```
 

--- a/website/docs/r/udpn_connection.html.markdown
+++ b/website/docs/r/udpn_connection.html.markdown
@@ -18,14 +18,14 @@ UDPN (UCloud Dedicated Private Network)，you can use Dedicated Private Network 
 
 ```hcl
 provider "ucloud" {
-    region = "cn-bj2"
+  region = "cn-bj2"
 }
 
 // connect provider's region (cn-bj2) and peer region (cn-sh2)
 resource "ucloud_udpn_connection" "example" {
-    bandwidth   = 2
-    peer_region = "cn-sh2"
-} 
+  bandwidth   = 2
+  peer_region = "cn-sh2"
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -15,11 +15,11 @@ Provides a VPC resource.
 
 ```hcl
 resource "ucloud_vpc" "example" {
-    name = "tf-example-vpc"
-    tag  = "tf-example"
+  name = "tf-example-vpc"
+  tag  = "tf-example"
 
-    # vpc network
-    cidr_blocks = ["192.168.0.0/16"]
+  # vpc network
+  cidr_blocks = ["192.168.0.0/16"]
 }
 ```
 

--- a/website/docs/r/vpc_peering_connection.html.markdown
+++ b/website/docs/r/vpc_peering_connection.html.markdown
@@ -14,20 +14,20 @@ Provides an VPC Peering Connection for establishing a connection between multipl
 
 ```hcl
 resource "ucloud_vpc" "foo" {
-    name        = "tf-example-vpc-01"
-    tag         = "tf-example"
-    cidr_blocks = ["192.168.0.0/16"]
+  name        = "tf-example-vpc-01"
+  tag         = "tf-example"
+  cidr_blocks = ["192.168.0.0/16"]
 }
 
 resource "ucloud_vpc" "bar" {
-    name        = "tf-example-vpc-02"
-    tag         = "tf-example"
-    cidr_blocks = ["10.10.0.0/16"]
+  name        = "tf-example-vpc-02"
+  tag         = "tf-example"
+  cidr_blocks = ["10.10.0.0/16"]
 }
 
 resource "ucloud_vpc_peering_connection" "connection" {
-    vpc_id      = ucloud_vpc.foo.id
-    peer_vpc_id = ucloud_vpc.bar.id
+  vpc_id      = ucloud_vpc.foo.id
+  peer_vpc_id = ucloud_vpc.bar.id
 }
 ```
 


### PR DESCRIPTION
Along with the release of Terraform v0.12, Terraform also introduces the officially recommended [Idiomatic Style Conventions](https://www.terraform.io/docs/configuration/style.html) for HCL languages. For better readability of the docs, the inline HCLs in docs should also follow that rule. 

This PR is trying to use a tool I developed to convert all the existing inline HCL codes into the canonical format.

Signed-off-by: imjoey <majunjiev@gmail.com>
