### PR TITLE
Fix to specify zero-value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 1.12.1 (Unreleased)
 
 BUG FIXES:
-* Fix the `duration` about it can specify zero-value distinguish from null-value[GH-44]
-* resource/ucloud_db_instance: Fix the `backup_begin_time` about it can specify zero-value distinguish from null-value[GH-44]
-* resource/ucloud_instance: Fix the content of return err about `cloud_normal` of `boot_disk_type` is not supported currently[GH-44]
-* resource/ucloud_lb_listener: Fix the `idle_timeout` about it can specify zero-value distinguish from null-value[GH-44]
+* Fix the `duration` about it can specify zero-value distinguish from null-value[GH-45]
+* resource/ucloud_db_instance: Fix the `backup_begin_time` about it can specify zero-value distinguish from null-value[GH-45]
+* resource/ucloud_instance: Fix the content of return err about `cloud_normal` of `boot_disk_type` is not supported currently[GH-45]
+* resource/ucloud_lb_listener: Fix the `idle_timeout` about it can specify zero-value distinguish from null-value[GH-45]
 
 ## 1.12.0 (August 23, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## 1.12.1 (Unreleased)
+
+BUG FIXES:
+* Fix the `duration` about it can specify zero-value distinguish from null-value[GH-44]
+* resource/ucloud_db_instance: Fix the `backup_begin_time` about it can specify zero-value distinguish from null-value[GH-44]
+* resource/ucloud_instance: Fix the content of return err about `cloud_normal` of `boot_disk_type` is not supported currently[GH-44]
+* resource/ucloud_lb_listener: Fix the `idle_timeout` about it can specify zero-value distinguish from null-value[GH-44]
+
 ## 1.12.0 (August 23, 2019)
 
 ENHANCEMENTS:

--- a/ucloud/config.go
+++ b/ucloud/config.go
@@ -52,7 +52,7 @@ func (c *Config) Client() (*UCloudClient, error) {
 	// enable auto retry with http/connection error
 	cfg.MaxRetries = c.MaxRetries
 	cfg.LogLevel = log.PanicLevel
-	cfg.UserAgent = "Terraform-UCloud/1.11.1"
+	cfg.UserAgent = "Terraform-UCloud/1.12.1"
 
 	if isAcc() {
 		//set DebugLevel for acceptance test

--- a/ucloud/resource_ucloud_db_instance.go
+++ b/ucloud/resource_ucloud_db_instance.go
@@ -232,7 +232,7 @@ func resourceUCloudDBInstanceCreate(d *schema.ResourceData, meta interface{}) er
 		req.Name = ucloud.String(resource.PrefixedUniqueId("tf-db-instance-"))
 	}
 
-	if v, ok := d.GetOk("duration"); ok {
+	if v, ok := d.GetOkExists("duration"); ok {
 		req.Quantity = ucloud.Int(v.(int))
 	} else {
 		req.Quantity = ucloud.Int(1)
@@ -364,7 +364,10 @@ func resourceUCloudDBInstanceUpdate(d *schema.ResourceData, meta interface{}) er
 		backupChanged = true
 	}
 
-	if d.HasChange("backup_begin_time") {
+	if v, ok := d.GetOkExists("backup_begin_time"); ok && d.IsNewResource() {
+		buReq.BackupTime = ucloud.Int(v.(int))
+		backupChanged = true
+	} else if d.HasChange("backup_begin_time") {
 		buReq.BackupTime = ucloud.Int(d.Get("backup_begin_time").(int))
 		backupChanged = true
 	}

--- a/ucloud/resource_ucloud_db_instance_test.go
+++ b/ucloud/resource_ucloud_db_instance_test.go
@@ -80,7 +80,7 @@ func TestAccUCloudDBInstance_backup(t *testing.T) {
 					resource.TestCheckResourceAttr("ucloud_db_instance.foo", "instance_type", "mysql-ha-1"),
 					resource.TestCheckResourceAttr("ucloud_db_instance.foo", "engine", "mysql"),
 					resource.TestCheckResourceAttr("ucloud_db_instance.foo", "engine_version", "5.7"),
-					resource.TestCheckResourceAttr("ucloud_db_instance.foo", "backup_begin_time", "4"),
+					resource.TestCheckResourceAttr("ucloud_db_instance.foo", "backup_begin_time", "0"),
 					resource.TestCheckResourceAttr("ucloud_db_instance.foo", "backup_count", "6"),
 					resource.TestCheckResourceAttr("ucloud_db_instance.foo", "backup_black_list.#", "1"),
 					resource.TestCheckResourceAttr("ucloud_db_instance.foo", "backup_black_list."+strconv.Itoa(schema.HashString("test.%")), "test.%"),
@@ -213,7 +213,7 @@ resource "ucloud_db_instance" "foo" {
 	engine 			  = "mysql"
 	engine_version	  = "5.7"
 	password 		  = "2018_UClou"
-	backup_begin_time = 4
+	backup_begin_time = 0
 	backup_count	  = 6
 	backup_black_list = ["test.%"]
 	backup_date 	  = "1111001"

--- a/ucloud/resource_ucloud_disk.go
+++ b/ucloud/resource_ucloud_disk.go
@@ -110,7 +110,7 @@ func resourceUCloudDiskCreate(d *schema.ResourceData, meta interface{}) error {
 	req.DiskType = ucloud.String(diskTypeCvt.unconvert(d.Get("disk_type").(string)))
 	req.ChargeType = ucloud.String(upperCamelCvt.unconvert(d.Get("charge_type").(string)))
 
-	if v, ok := d.GetOk("duration"); ok {
+	if v, ok := d.GetOkExists("duration"); ok {
 		req.Quantity = ucloud.Int(v.(int))
 	} else {
 		req.Quantity = ucloud.Int(1)

--- a/ucloud/resource_ucloud_eip.go
+++ b/ucloud/resource_ucloud_eip.go
@@ -156,7 +156,6 @@ func resourceUCloudEIPCreate(d *schema.ResourceData, meta interface{}) error {
 
 	req := conn.NewAllocateEIPRequest()
 	req.ChargeType = ucloud.String(upperCamelCvt.unconvert(d.Get("charge_type").(string)))
-	req.PayMode = ucloud.String(upperCamelCvt.unconvert(d.Get("charge_mode").(string)))
 	req.OperatorName = ucloud.String(upperCamelCvt.unconvert(d.Get("internet_type").(string)))
 
 	if v, ok := d.GetOk("charge_mode"); ok {
@@ -171,7 +170,7 @@ func resourceUCloudEIPCreate(d *schema.ResourceData, meta interface{}) error {
 		req.Bandwidth = ucloud.Int(1)
 	}
 
-	if v, ok := d.GetOk("duration"); ok {
+	if v, ok := d.GetOkExists("duration"); ok {
 		req.Quantity = ucloud.Int(v.(int))
 	} else {
 		req.Quantity = ucloud.Int(1)

--- a/ucloud/resource_ucloud_instance_test.go
+++ b/ucloud/resource_ucloud_instance_test.go
@@ -287,6 +287,8 @@ resource "ucloud_instance" "foo" {
   security_group    = "${ucloud_security_group.default.id}"
   instance_type     = "n-highcpu-1"
   root_password     = "wA1234567"
+  charge_type 		= "month"
+  duration			= 0
   name              = "tf-acc-instance-config-basic"
   tag               = "tf-acc"
 }`, rInt)
@@ -319,6 +321,8 @@ resource "ucloud_instance" "foo" {
   security_group    = "${ucloud_security_group.default.id}"
   instance_type     = "n-basic-2"
   root_password     = "wA1234567"
+  charge_type 		= "month"
+  duration			= 0
   name              = "tf-acc-instance-config-basic-update"
   tag               = ""
 }`, rInt)

--- a/ucloud/resource_ucloud_instance_test.go
+++ b/ucloud/resource_ucloud_instance_test.go
@@ -287,8 +287,8 @@ resource "ucloud_instance" "foo" {
   security_group    = "${ucloud_security_group.default.id}"
   instance_type     = "n-highcpu-1"
   root_password     = "wA1234567"
-  charge_type 		= "month"
-  duration			= 0
+  charge_type       = "month"
+  duration          = 0
   name              = "tf-acc-instance-config-basic"
   tag               = "tf-acc"
 }`, rInt)
@@ -321,8 +321,8 @@ resource "ucloud_instance" "foo" {
   security_group    = "${ucloud_security_group.default.id}"
   instance_type     = "n-basic-2"
   root_password     = "wA1234567"
-  charge_type 		= "month"
-  duration			= 0
+  charge_type       = "month"
+  duration          = 0
   name              = "tf-acc-instance-config-basic-update"
   tag               = ""
 }`, rInt)

--- a/ucloud/resource_ucloud_lb_listener.go
+++ b/ucloud/resource_ucloud_lb_listener.go
@@ -190,7 +190,7 @@ func resourceUCloudLBListenerCreate(d *schema.ResourceData, meta interface{}) er
 		req.VServerName = ucloud.String(resource.PrefixedUniqueId("tf-lb-listener-"))
 	}
 
-	if v, ok := d.GetOk("idle_timeout"); ok {
+	if v, ok := d.GetOkExists("idle_timeout"); ok {
 		req.ClientTimeout = ucloud.Int(v.(int))
 	}
 

--- a/ucloud/resource_ucloud_memcache_instance.go
+++ b/ucloud/resource_ucloud_memcache_instance.go
@@ -128,7 +128,7 @@ func resourceUCloudMemcacheInstanceCreate(d *schema.ResourceData, meta interface
 	req.ChargeType = ucloud.String(upperCamelCvt.unconvert(d.Get("charge_type").(string)))
 	req.Protocol = ucloud.String("memcache")
 
-	if v, ok := d.GetOk("duration"); ok {
+	if v, ok := d.GetOkExists("duration"); ok {
 		req.Quantity = ucloud.Int(v.(int))
 	} else {
 		req.Quantity = ucloud.Int(1)

--- a/ucloud/resource_ucloud_redis_instance.go
+++ b/ucloud/resource_ucloud_redis_instance.go
@@ -193,7 +193,7 @@ func createActiveStandbyRedisInstance(d *schema.ResourceData, meta interface{}) 
 	req.ChargeType = ucloud.String(upperCamelCvt.unconvert(d.Get("charge_type").(string)))
 	req.HighAvailability = ucloud.String("enable")
 
-	if v, ok := d.GetOk("duration"); ok {
+	if v, ok := d.GetOkExists("duration"); ok {
 		req.Quantity = ucloud.Int(v.(int))
 	} else {
 		req.Quantity = ucloud.Int(1)

--- a/ucloud/resource_ucloud_udpn_connection.go
+++ b/ucloud/resource_ucloud_udpn_connection.go
@@ -80,7 +80,7 @@ func resourceUCloudUDPNConnectionCreate(d *schema.ResourceData, meta interface{}
 	req.Bandwidth = ucloud.Int(d.Get("bandwidth").(int))
 	req.ChargeType = ucloud.String(upperCamelCvt.unconvert(d.Get("charge_type").(string)))
 
-	if v, ok := d.GetOk("duration"); ok {
+	if v, ok := d.GetOkExists("duration"); ok {
 		req.Quantity = ucloud.Int(v.(int))
 	} else {
 		req.Quantity = ucloud.Int(1)


### PR DESCRIPTION
BUG FIXES:

* Fix the `duration` about it can specify zero-value distinguish from null-value
* resource/ucloud_db_instance: Fix the `backup_begin_time` about it can specify zero-value distinguish from null-value
* resource/ucloud_instance: Fix the content of return err about `cloud_normal` of `boot_disk_type` is not supported currently
* resource/ucloud_lb_listener: Fix the `idle_timeout` about it can specify zero-value distinguish from null-value