### PR TITLE
fix lb ssl attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ BUG FIXES:
 * resource/ucloud_db_instance: Fix the `backup_begin_time` about it can specify zero-value distinguish from null-value[GH-45]
 * resource/ucloud_instance: Fix the content of return err about `cloud_normal` of `boot_disk_type` is not supported currently[GH-45]
 * resource/ucloud_lb_listener: Fix the `idle_timeout` about it can specify zero-value distinguish from null-value[GH-45]
+* resource/ucloud_lb_ssl_attachment: Fix the inaccurate plan about creating lb ssl attachment[GH-46]
+* resource/ucloud_lb_ssl_attachment: Fix the api err about deleting lb ssl attachment[GH-46]
 
 ## 1.12.0 (August 23, 2019)
 


### PR DESCRIPTION
BUG FIXES:

* resource/ucloud_lb_ssl_attachment: Fix the inaccurate plan about creating lb ssl attachment
* resource/ucloud_lb_ssl_attachment: Fix the api err about deleting lb ssl attachment