### PR TITLE
fix error about update db instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 1.25.0 (Unreleased)
+## 1.24.1 (Unreleased)
+
+BUG FIXES:
+
+* resource/ucloud_db_instance: Fix the error about updating only one of `instance_storage` and `instance_type`.
+
 ## 1.24.0 (2020-10-23)
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* resource/ucloud_db_instance: Fix the error about updating only one of `instance_storage` and `instance_type`.
+* resource/ucloud_db_instance: Fix the error about updating only one of `instance_storage` and `instance_type`. [GH-86]
 
 ## 1.24.0 (2020-10-23)
 

--- a/ucloud/config.go
+++ b/ucloud/config.go
@@ -62,7 +62,7 @@ func (c *Config) Client() (*UCloudClient, error) {
 	// enable auto retry with http/connection error
 	cfg.MaxRetries = c.MaxRetries
 	cfg.LogLevel = log.PanicLevel
-	cfg.UserAgent = "Terraform-UCloud/1.24.0"
+	cfg.UserAgent = "Terraform-UCloud/1.24.1"
 	cfg.BaseUrl = c.BaseURL
 
 	cred := auth.NewCredential()

--- a/ucloud/resource_ucloud_db_instance.go
+++ b/ucloud/resource_ucloud_db_instance.go
@@ -429,15 +429,16 @@ func resourceUCloudDBInstanceUpdate(d *schema.ResourceData, meta interface{}) er
 		newDbType, _ := parseDBInstanceType(newType.(string))
 		if oldDbType.Memory != newDbType.Memory {
 			sizeReq.MemoryLimit = ucloud.Int(newDbType.Memory * 1000)
+			sizeReq.DiskSpace = ucloud.Int(d.Get("instance_storage").(int))
 			isSizeChanged = true
 		}
 	}
 
 	if d.HasChange("instance_storage") && !d.IsNewResource() {
 		dbType, _ := parseDBInstanceType(d.Get("instance_type").(string))
-		instanceStorage := d.Get("instance_storage").(int)
-		sizeReq.DiskSpace = ucloud.Int(instanceStorage)
+		sizeReq.DiskSpace = ucloud.Int(d.Get("instance_storage").(int))
 		sizeReq.InstanceType = ucloud.String(dbTypeCvt.convert(dbType.Type))
+		sizeReq.MemoryLimit = ucloud.Int(dbType.Memory * 1000)
 		isSizeChanged = true
 	}
 


### PR DESCRIPTION
BUG FIXES:

* resource/ucloud_db_instance: Fix the error about updating only one of `instance_storage` and `instance_type`.