### PR TITLE
Add charge_type variable for redis

### DIFF
--- a/examples/redis/main.tf
+++ b/examples/redis/main.tf
@@ -38,5 +38,6 @@ resource "ucloud_redis_instance" "master" {
   subnet_id = ucloud_subnet.default.id
   backup_begin_time = 3
   auto_backup = "disable"
+  charge_type = var.charge_type
 }
 

--- a/examples/redis/variables.tf
+++ b/examples/redis/variables.tf
@@ -10,3 +10,8 @@ variable "redis_password" {
   default = "2018_UClou"
 }
 
+variable "charge_type" {
+  description = "charge type"
+  type = string
+  default = "month"
+}


### PR DESCRIPTION
By adding variable charge_type will help users who tends to pay-as-a-go to
provision Redis cloud resource. And it won't affect the original design as
the default value of the variable `month` is the same as before.