### PR TITLE
Avoid pass BackupId when from_backup_id is absent

### DIFF
--- a/ucloud/resource_ucloud_db_instance.go
+++ b/ucloud/resource_ucloud_db_instance.go
@@ -238,7 +238,10 @@ func resourceUCloudDBInstanceCreate(d *schema.ResourceData, meta interface{}) er
 	req.DBTypeId = ucloud.String(dbTypeId)
 	req.BackupCount = ucloud.Int(d.Get("backup_count").(int))
 	req.InstanceType = ucloud.String(dbTypeCvt.convert(dbType.Type))
-	req.BackupId = ucloud.Int(d.Get("from_backup_id").(int))
+
+	if v, ok := d.GetOk("from_backup_id"); ok {
+		req.BackupId = ucloud.Int(v.(int))
+	}
 
 	password := fmt.Sprintf("%s%s%s",
 		acctest.RandStringFromCharSet(5, defaultPasswordStr),

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -15,13 +15,11 @@ Provides a Database instance resource.
 ## Example Usage
 
 ```hcl
-# Query availability zone
-data "ucloud_zones" "default" {
-}
 
 # Create database instance
 resource "ucloud_db_instance" "master" {
   name              = "tf-example-db"
+  availability_zone = "cn-bj2-05"
   instance_storage  = 20
   instance_type     = "mysql-ha-1"
   engine            = "mysql"


### PR DESCRIPTION
Avoid pass BackupId when from_backup_id is absent and add `availability_zone` to example.