### PR TITLE
feat: align uk8s params with new API and add uk8s images datasource

### DIFF
--- a/ucloud/data_source_ucloud_uk8s_images.go
+++ b/ucloud/data_source_ucloud_uk8s_images.go
@@ -1,0 +1,138 @@
+package ucloud
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/ucloud/ucloud-sdk-go/services/uk8s"
+	"github.com/ucloud/ucloud-sdk-go/ucloud"
+)
+
+func dataSourceUCloudUK8SImages() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceUCloudUK8SImagesRead,
+		Schema: map[string]*schema.Schema{
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.ValidateRegexp,
+			},
+
+			"host_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "uhost",
+				ValidateFunc: validation.StringInSlice([]string{"uhost", "uphost"}, false),
+			},
+
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"total_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"images": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"zone_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
+						"not_support_gpu": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceUCloudUK8SImagesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*UCloudClient).uk8sconn
+
+	req := conn.NewDescribeUK8SImageRequest()
+
+	if v, ok := d.GetOk("availability_zone"); ok {
+		req.Zone = ucloud.String(v.(string))
+	}
+
+	resp, err := conn.DescribeUK8SImage(req)
+	if err != nil {
+		return fmt.Errorf("error on reading uk8s image list, %s", err)
+	}
+
+	var images []uk8s.ImageInfo
+	if d.Get("host_type").(string) == "uphost" {
+		images = resp.PHostImageSet
+	} else {
+		images = resp.ImageSet
+	}
+
+	var filteredImages []uk8s.ImageInfo
+	if nameRegex, ok := d.GetOk("name_regex"); ok {
+		r := regexp.MustCompile(nameRegex.(string))
+		for _, image := range images {
+			if r.MatchString(image.ImageName) {
+				filteredImages = append(filteredImages, image)
+			}
+		}
+	} else {
+		filteredImages = images
+	}
+
+	return dataSourceUCloudUK8SImagesSave(d, filteredImages)
+}
+
+func dataSourceUCloudUK8SImagesSave(d *schema.ResourceData, images []uk8s.ImageInfo) error {
+	var ids []string
+	var data []map[string]interface{}
+
+	for _, item := range images {
+		ids = append(ids, item.ImageId)
+		data = append(data, map[string]interface{}{
+			"id":              item.ImageId,
+			"name":            item.ImageName,
+			"zone_id":         item.ZoneId,
+			"not_support_gpu": item.NotSupportGPU,
+		})
+	}
+
+	d.SetId(hashStringArray(ids))
+	_ = d.Set("total_count", len(data))
+	if err := d.Set("images", data); err != nil {
+		return err
+	}
+
+	if outputFile, ok := d.GetOk("output_file"); ok && outputFile.(string) != "" {
+		writeToFile(outputFile.(string), data)
+	}
+
+	return nil
+}

--- a/ucloud/data_source_ucloud_uk8s_images_test.go
+++ b/ucloud/data_source_ucloud_uk8s_images_test.go
@@ -1,0 +1,34 @@
+package ucloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccUCloudUK8SImagesDataSource(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataUK8SImagesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIDExists("data.ucloud_uk8s_images.foo"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataUK8SImagesConfig = `
+data "ucloud_zones" "default" {
+}
+
+data "ucloud_uk8s_images" "foo" {
+	availability_zone = "${data.ucloud_zones.default.zones.0.id}"
+	host_type         = "uhost"
+}
+`

--- a/ucloud/provider.go
+++ b/ucloud/provider.go
@@ -115,6 +115,7 @@ func Provider() terraform.ResourceProvider {
 			"ucloud_baremetal_images":      dataSourceUCloudBareMetalImages(),
 			"ucloud_labels":                dataSourceUCloudLabels(),
 			"ucloud_label_resources":       dataSourceUCloudLabelResources(),
+			"ucloud_uk8s_images":           dataSourceUCloudUK8SImages(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/ucloud/resource_ucloud_uk8s_cluster.go
+++ b/ucloud/resource_ucloud_uk8s_cluster.go
@@ -105,6 +105,12 @@ func resourceUCloudUK8SCluster() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"enable_external_api_server": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -153,9 +159,35 @@ func resourceUCloudUK8SCluster() *schema.Resource {
 
 						"instance_type": {
 							Type:         schema.TypeString,
-							Required:     true,
+							Optional:     true,
 							ForceNew:     true,
+							Deprecated:   "attribute `instance_type` is deprecated, use `cpu`, `memory` and `machine_type` instead",
 							ValidateFunc: validateInstanceType,
+						},
+
+						"cpu": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"memory": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.IntBetween(1024, 262144),
+						},
+
+						"machine_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"N",
+								"C",
+								"O",
+								"OS",
+							}, false),
 						},
 
 						"boot_disk_type": {
@@ -170,6 +202,13 @@ func resourceUCloudUK8SCluster() *schema.Resource {
 								"cloud_ssd",
 								"cloud_rssd",
 							}, false),
+						},
+
+						"boot_disk_size": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
 						},
 
 						"data_disk_size": {
@@ -330,16 +369,26 @@ func resourceUCloudUK8SClusterCreate(d *schema.ResourceData, meta interface{}) e
 		req.Master = append(req.Master, masterNode)
 	}
 
-	// skip error because it has been validated by schema
-	mt, _ := parseInstanceType(master["instance_type"].(string))
-	req.MasterCPU = ucloud.Int(mt.CPU)
-	req.MasterMem = ucloud.Int(mt.Memory)
-	req.MasterMachineType = ucloud.String(strings.ToUpper(mt.HostType))
+	// skip error because it has been validated by schema and CustomizeDiff
+	cpu, memMB, machineType, err := resolveUK8SMachine(
+		func(k string) interface{} { return master[k] },
+		"cpu", "memory", "machine_type", "instance_type",
+	)
+	if err != nil {
+		return err
+	}
+	req.MasterCPU = ucloud.Int(cpu)
+	req.MasterMem = ucloud.Int(memMB)
+	req.MasterMachineType = ucloud.String(machineType)
 
 	if len(master["boot_disk_type"].(string)) != 0 {
 		req.MasterBootDiskType = ucloud.String(upperCvt.unconvert(master["boot_disk_type"].(string)))
 	} else {
 		req.MasterBootDiskType = ucloud.String(upperCvt.unconvert("cloud_ssd"))
+	}
+
+	if master["boot_disk_size"].(int) != 0 {
+		req.MasterBootDiskSize = ucloud.Int(master["boot_disk_size"].(int))
 	}
 
 	if master["data_disk_size"].(int) != 0 {
@@ -352,9 +401,13 @@ func resourceUCloudUK8SClusterCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if len(master["min_cpu_platform"].(string)) != 0 {
-		req.MasterMinmalCpuPlatform = ucloud.String(master["min_cpu_platform"].(string))
+		req.MasterMinimalCpuPlatform = ucloud.String(master["min_cpu_platform"].(string))
 	} else {
-		req.MasterMinmalCpuPlatform = ucloud.String("Intel/Auto")
+		req.MasterMinimalCpuPlatform = ucloud.String("Intel/Auto")
+	}
+
+	if v, ok := d.GetOk("tag"); ok {
+		req.Tag = ucloud.String(v.(string))
 	}
 
 	resp, err := conn.CreateUK8SClusterV2(req)
@@ -483,7 +536,10 @@ func resourceUCloudUK8SClusterDelete(d *schema.ResourceData, meta interface{}) e
 
 func diffValidateBootDiskTypeWithInstanceTypeOfUK8sCluster(diff *schema.ResourceDiff, meta interface{}) error {
 	master := diff.Get("master").([]interface{})[0].(map[string]interface{})
-	mt, err := parseInstanceType(master["instance_type"].(string))
+	_, _, machineType, err := resolveUK8SMachine(
+		func(k string) interface{} { return master[k] },
+		"cpu", "memory", "machine_type", "instance_type",
+	)
 	if err != nil {
 		return err
 	}
@@ -495,7 +551,7 @@ func diffValidateBootDiskTypeWithInstanceTypeOfUK8sCluster(diff *schema.Resource
 		bootDiskType = "cloud_ssd"
 	}
 
-	if strings.Contains(mt.HostType, "o") && isStringIn(bootDiskType, []string{
+	if strings.Contains(strings.ToLower(machineType), "o") && isStringIn(bootDiskType, []string{
 		"local_normal",
 		"local_ssd",
 		"cloud_ssd",

--- a/ucloud/resource_ucloud_uk8s_node.go
+++ b/ucloud/resource_ucloud_uk8s_node.go
@@ -65,9 +65,87 @@ func resourceUCloudUK8SNode() *schema.Resource {
 
 			"instance_type": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
+				Deprecated:   "attribute `instance_type` is deprecated, use `cpu`, `memory` and `machine_type` instead",
 				ValidateFunc: validateInstanceType,
+			},
+
+			"cpu": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"memory": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntBetween(1024, 262144),
+			},
+
+			"machine_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"N",
+					"C",
+					"G",
+					"O",
+					"OS",
+				}, false),
+			},
+
+			"gpu": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"gpu_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"max_pods": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"taints": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"labels": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
 			},
 
 			"charge_type": {
@@ -101,6 +179,13 @@ func resourceUCloudUK8SNode() *schema.Resource {
 					"cloud_ssd",
 					"cloud_rssd",
 				}, false),
+			},
+
+			"boot_disk_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 
 			"data_disk_size": {
@@ -273,16 +358,39 @@ func resourceUK8SNodeCreate(d *schema.ResourceData, meta interface{}) error {
 		req.IsolationGroup = ucloud.String(v.(string))
 	}
 
-	// skip error because it has been validated by schema
-	mt, _ := parseInstanceType(d.Get("instance_type").(string))
-	req.CPU = ucloud.Int(mt.CPU)
-	req.Mem = ucloud.Int(mt.Memory)
-	req.MachineType = ucloud.String(strings.ToUpper(mt.HostType))
+	// skip error because it has been validated by schema and CustomizeDiff
+	cpu, memMB, machineType, err := resolveUK8SMachine(d.Get, "cpu", "memory", "machine_type", "instance_type")
+	if err != nil {
+		return err
+	}
+	req.CPU = ucloud.Int(cpu)
+	req.Mem = ucloud.Int(memMB)
+	req.MachineType = ucloud.String(machineType)
+
+	if v, ok := d.GetOk("gpu"); ok {
+		req.GPU = ucloud.Int(v.(int))
+	}
+
+	if v, ok := d.GetOk("gpu_type"); ok {
+		req.GpuType = ucloud.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("taints"); ok {
+		req.Taints = ucloud.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("tag"); ok {
+		req.Tag = ucloud.String(v.(string))
+	}
 
 	if v, ok := d.GetOk("boot_disk_type"); ok {
 		req.BootDiskType = ucloud.String(upperCvt.unconvert(v.(string)))
 	} else {
 		req.BootDiskType = ucloud.String(upperCvt.unconvert("cloud_ssd"))
+	}
+
+	if v, ok := d.GetOk("boot_disk_size"); ok {
+		req.BootDiskSize = ucloud.Int(v.(int))
 	}
 
 	if v, ok := d.GetOk("data_disk_size"); ok {
@@ -295,9 +403,9 @@ func resourceUK8SNodeCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("min_cpu_platform"); ok {
-		req.MinmalCpuPlatform = ucloud.String(v.(string))
+		req.MinimalCpuPlatform = ucloud.String(v.(string))
 	} else {
-		req.MinmalCpuPlatform = ucloud.String("Intel/Auto")
+		req.MinimalCpuPlatform = ucloud.String("Intel/Auto")
 	}
 
 	if v, ok := d.GetOk("max_pods"); ok {
@@ -316,7 +424,7 @@ func resourceUK8SNodeCreate(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := conn.AddUK8SUHostNode(req)
 	if err != nil {
-		return fmt.Errorf("error on creating uk8s cluster, %s", err)
+		return fmt.Errorf("error on creating uk8s node, %s", uk8sErrorWithMessage(err, resp.Message))
 	}
 
 	d.SetId(resp.NodeIds[0])
@@ -408,15 +516,15 @@ func resourceUK8SNodeDelete(d *schema.ResourceData, meta interface{}) error {
 				return resource.RetryableError(fmt.Errorf("the specified k8s cluster %q has not been deleted due to unknown error", d.Id()))
 			}
 		}
-		if _, err := conn.DelUK8SClusterNodeV2(deleReq); err != nil {
-			return resource.RetryableError(fmt.Errorf("error on deleting k8s cluster %q, %s", d.Id(), err))
+		if resp, err := conn.DelUK8SClusterNodeV2(deleReq); err != nil {
+			return resource.RetryableError(fmt.Errorf("error on deleting k8s cluster %q, %s", d.Id(), uk8sErrorWithMessage(err, resp.Message)))
 		}
 		return resource.RetryableError(fmt.Errorf("the specified k8s cluster %q has not been deleted due to unknown error", d.Id()))
 	})
 }
 
 func diffValidateBootDiskTypeWithInstanceTypeOfUK8sNode(diff *schema.ResourceDiff, meta interface{}) error {
-	mt, err := parseInstanceType(diff.Get("instance_type").(string))
+	_, _, machineType, err := resolveUK8SMachine(diff.Get, "cpu", "memory", "machine_type", "instance_type")
 	if err != nil {
 		return err
 	}
@@ -428,7 +536,7 @@ func diffValidateBootDiskTypeWithInstanceTypeOfUK8sNode(diff *schema.ResourceDif
 		bootDiskType = "cloud_ssd"
 	}
 
-	if strings.Contains(mt.HostType, "o") && isStringIn(bootDiskType, []string{
+	if strings.Contains(strings.ToLower(machineType), "o") && isStringIn(bootDiskType, []string{
 		"local_normal",
 		"local_ssd",
 		"cloud_ssd",

--- a/ucloud/service_ucloud_uk8s.go
+++ b/ucloud/service_ucloud_uk8s.go
@@ -2,11 +2,59 @@ package ucloud
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ucloud/ucloud-sdk-go/services/uk8s"
 	"github.com/ucloud/ucloud-sdk-go/ucloud"
 	uerr "github.com/ucloud/ucloud-sdk-go/ucloud/error"
 )
+
+// resolveUK8SMachine resolves the cpu/mem(MB)/machineType for a uk8s master or
+// node from the new dedicated fields (cpu/memory/machine_type). It falls back to
+// parsing the deprecated instance_type string when machine_type is not set, so
+// existing configurations keep working. The get callback maps a schema key
+// (already prefixed by the caller, e.g. "master.0.cpu") to its value, allowing
+// the same logic to serve both *schema.ResourceData and *schema.ResourceDiff.
+func resolveUK8SMachine(get func(string) interface{}, cpuKey, memKey, machineTypeKey, instanceTypeKey string) (cpu, memMB int, machineType string, err error) {
+	if mt, ok := get(machineTypeKey).(string); ok && mt != "" {
+		machineType = strings.ToUpper(mt)
+		cpu, _ = get(cpuKey).(int)
+		memMB, _ = get(memKey).(int)
+		if cpu <= 0 {
+			return 0, 0, "", fmt.Errorf("%q must be set and greater than 0 when %q is set", cpuKey, machineTypeKey)
+		}
+		if memMB <= 0 {
+			return 0, 0, "", fmt.Errorf("%q must be set and greater than 0 when %q is set", memKey, machineTypeKey)
+		}
+		return cpu, memMB, machineType, nil
+	}
+
+	if it, ok := get(instanceTypeKey).(string); ok && it != "" {
+		t, err := parseInstanceType(it)
+		if err != nil {
+			return 0, 0, "", err
+		}
+		return t.CPU, t.Memory, strings.ToUpper(t.HostType), nil
+	}
+
+	return 0, 0, "", fmt.Errorf("one of %q or %q must be set", machineTypeKey, instanceTypeKey)
+}
+
+// uk8sErrorWithMessage compensates for a bug in some uk8s SDK response structs
+// (e.g. AddUK8SUHostNodeResponse, DelUK8SClusterNodeV2Response) that redeclare a
+// `Message` field, shadowing response.CommonBase.Message. Because the SDK builds
+// its error from CommonBase.Message via GetMessage(), the real reason returned by
+// the backend (e.g. "resource not enough") lands in the shadowing field and is
+// lost from err. This appends that field back when it carries extra information.
+func uk8sErrorWithMessage(err error, respMessage string) error {
+	if err == nil {
+		return nil
+	}
+	if respMessage != "" && !strings.Contains(err.Error(), respMessage) {
+		return fmt.Errorf("%s %s", err, respMessage)
+	}
+	return err
+}
 
 func (client *UCloudClient) describeUK8SClusterById(instanceId string) (*uk8s.ClusterSet, error) {
 	if instanceId == "" {

--- a/website/docs/d/uk8s_images.html.markdown
+++ b/website/docs/d/uk8s_images.html.markdown
@@ -1,0 +1,47 @@
+---
+subcategory: "UK8S"
+layout: "ucloud"
+page_title: "UCloud: ucloud_uk8s_images"
+description: |-
+  Provides a list of UK8S available images in the current region.
+---
+
+# ucloud_uk8s_images
+
+This data source provides a list of images supported by UK8S, which can be used to create UK8S clusters and nodes. Regular `ucloud_images` cannot be used for UK8S, use this data source instead.
+
+## Example Usage
+
+```hcl
+data "ucloud_uk8s_images" "default" {
+  availability_zone = "cn-bj2-02"
+  name_regex        = "^Ubuntu"
+}
+
+output "first_image_id" {
+  value = data.ucloud_uk8s_images.default.images.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `availability_zone` - (Optional) Availability zone where images are located. such as: `cn-bj2-02`. You may refer to [list of availability zone](https://docs.ucloud.cn/api/summary/regionlist)
+* `host_type` - (Optional) The host type of the images. Possible values are: `uhost` for cloud host images, `uphost` for physical cloud host images. (Default: `uhost`).
+* `name_regex` - (Optional) A regex string to filter resulting images by name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `total_count` - Total number of images that satisfy the condition.
+* `images` - It is a nested type which documented below.
+
+The attribute (`images`) supports the following:
+
+* `id` - The ID of image.
+* `name` - The name of image.
+* `zone_id` - The ID of the availability zone where the image is located.
+* `not_support_gpu` - Whether the image does not support GPU machine type.

--- a/website/docs/r/uk8s_cluster.html.markdown
+++ b/website/docs/r/uk8s_cluster.html.markdown
@@ -42,7 +42,9 @@ resource "ucloud_uk8s_cluster" "foo" {
       "${data.ucloud_zones.default.zones.0.id}",
       "${data.ucloud_zones.default.zones.0.id}",
     ]
-    instance_type = "n-basic-2"
+    cpu          = 2
+    memory       = 4096
+    machine_type = "N"
   }
 }
 ```
@@ -69,13 +71,18 @@ The following arguments are supported:
 * `kube_proxy` - (Optional, ForceNew) The configuration of kube proxy, See [kube proxy](#kube_proxy) for details of attributes.
 * `master` - (Optional, ForceNew) The configuration of master, See [master](#master) for details of attributes.
 * `image_id` - (Optional, ForceNew) The ID for the image to use for the master nodes.
+* `tag` - (Optional, ForceNew) The business group of the cluster.
 
 ### master
 
 The `master` supports the following:
 
 * `availability_zones` - (Required, ForceNew) Availability zone list where instance is located. such as: `["cn-bj2-02", "cn-bj2-03", "cn-bj2-05"]`. You may refer to [list of availability zone](https://docs.ucloud.cn/api/summary/regionlist)
-* `instance_type` - (Required, ForceNew) The type of instance, please visit the [instance type table](https://docs.ucloud.cn/terraform/specification/instance)
+* `cpu` - (Optional, ForceNew) The number of virtual CPU cores of the master node. Required together with `memory` and `machine_type`. This replaces the deprecated `instance_type`.
+* `memory` - (Optional, ForceNew) The size of memory of the master node, measured in MB (MegaByte). Required together with `cpu` and `machine_type`.
+* `machine_type` - (Optional, ForceNew) The machine type of the master node. Possible values are: `N`, `C`, `O`, `OS`. Required together with `cpu` and `memory`.
+* `instance_type` - (Optional, ForceNew, **Deprecated**) The type of instance, please visit the [instance type table](https://docs.ucloud.cn/terraform/specification/instance). Deprecated, use `cpu`, `memory` and `machine_type` instead.
+* `boot_disk_size` - (Optional, ForceNew) The size of boot disk of the master node, measured in GB (GigaByte). Range: [40, 500].
 * `boot_disk_type` - (Optional, ForceNew) The type of boot disk. Possible values are: `local_normal` and `local_ssd` for local boot disk, `cloud_ssd` for cloud SSD boot disk,`rssd_data_disk` as RDMA-SSD cloud disk. (Default: `cloud_ssd`). The `local_ssd` and `cloud_ssd` are not fully support by all regions as boot disk type, please proceed to UCloud console for more details.
 * `data_disk_type` - (Optional, ForceNew) The type of local data disk. Possible values are: `local_normal` and `local_ssd` for local data disk. (Default: `cloud_ssd`). The `local_ssd` is not fully support by all regions as data disk type, please proceed to UCloud console for more details. In addition, the `data_disk_type` must be same as `boot_disk_type` if specified.
 * `data_disk_size` - (Optional, ForceNew) The size of local data disk, measured in GB (GigaByte), 20-2000 for local sata disk and 20-1000 for local ssd disk (all the GPU type instances are included). The volume adjustment must be a multiple of 10 GB. In addition, any reduction of data disk size is not supported.

--- a/website/docs/r/uk8s_node.html.markdown
+++ b/website/docs/r/uk8s_node.html.markdown
@@ -43,7 +43,9 @@ resource "ucloud_uk8s_cluster" "foo" {
       "${data.ucloud_zones.default.zones.0.id}",
       "${data.ucloud_zones.default.zones.0.id}",
     ]
-    instance_type = "n-basic-2"
+    cpu          = 2
+    memory       = 4096
+    machine_type = "N"
   }
 }
 
@@ -51,10 +53,12 @@ resource "ucloud_uk8s_node" "foo" {
   cluster_id    = "${ucloud_uk8s_cluster.foo.id}"
   subnet_id     = "${ucloud_subnet.foo.id}"
   password      = "ucloud_2021"
-  instance_type = "n-basic-2"
+  cpu           = 2
+  memory        = 4096
+  machine_type  = "N"
   charge_type   = "dynamic"
   availability_zone = "${data.ucloud_zones.default.zones.0.id}"
-  
+
   count = 2
 }
 ```
@@ -67,9 +71,20 @@ The following arguments are supported:
 * `cluster_id` - (Required, ForceNew) The ID of uk8s cluster.
 * `image_id` - (Required, ForceNew) The ID for the image to use for the instance.
 * `password` - (Required, ForceNew) The password for the instance, which contains 8-30 characters, and at least 2 items of capital letters, lower case letters, numbers and special characters. The special characters include <code>`()~!@#$%^&*-+=_|{}\[]:;'<>,.?/</code>. If not specified, terraform will auto-generate a password.
-* `instance_type` - (Required, ForceNew) The type of instance, please visit the [instance type table](https://docs.ucloud.cn/terraform/specification/instance)
-  
+* `cpu` - (Optional, ForceNew) The number of virtual CPU cores of the node. Required together with `memory` and `machine_type`. This replaces the deprecated `instance_type`.
+* `memory` - (Optional, ForceNew) The size of memory of the node, measured in MB (MegaByte). Required together with `cpu` and `machine_type`.
+* `machine_type` - (Optional, ForceNew) The machine type of the node. Possible values are: `N`, `C`, `G`, `O`, `OS`. Required together with `cpu` and `memory`.
+* `instance_type` - (Optional, ForceNew, **Deprecated**) The type of instance, please visit the [instance type table](https://docs.ucloud.cn/terraform/specification/instance). Deprecated, use `cpu`, `memory` and `machine_type` instead.
+
 ---
+
+* `gpu` - (Optional, ForceNew) The number of GPU cores of the node. Only supported by GPU machine type (`G`).
+* `gpu_type` - (Optional, ForceNew) The GPU type of the node. Required when `machine_type` is `G`.
+* `max_pods` - (Optional, ForceNew) The maximum number of pods that can be scheduled onto the node. (Default: `110`).
+* `taints` - (Optional, ForceNew) The taints of the node, formatted as `key=value:effect`, multiple taints separated by comma, up to 5 groups. e.g. `key1=value1:NoSchedule,key2=value2:NoExecute`.
+* `tag` - (Optional, ForceNew) The business group of the node.
+* `labels` - (Optional, ForceNew) The labels of the node, it is a nested type which documented below. Up to 5 labels are supported.
+* `boot_disk_size` - (Optional, ForceNew) The size of boot disk, measured in GB (GigaByte). Range: [40, 500].
 
 * `charge_type` - (Optional, ForceNew) The charge type of instance, possible values are: `year`, `month` and `dynamic` as pay by hour (specific permission required). (Default: `month`).
 * `duration` - (Optional, ForceNew) The duration that you will buy the instance (Default: `1`). The value is `0` when pay by month and the instance will be valid till the last day of that month. It is not required when `dynamic` (pay by hour).
@@ -124,3 +139,10 @@ The attribute (`ip_set`) supports the following:
 
 * `internet_type` - Type of Elastic IP routes. Possible values are: `International` as international BGP IP, `BGP` as china BGP IP and `Private` as private IP.
 * `ip` - Elastic IP address.
+
+- - -
+
+The argument (`labels`) supports the following:
+
+* `key` - (Required, ForceNew) The key of the label.
+* `value` - (Required, ForceNew) The value of the label.


### PR DESCRIPTION
- resource/ucloud_uk8s_cluster: support cpu/memory/machine_type in master block and deprecate instance_type; add tag and boot_disk_size
- resource/ucloud_uk8s_node: support cpu/memory/machine_type and deprecate instance_type; add gpu/gpu_type/max_pods/taints/tag/boot_disk_size/labels
- resource/ucloud_uk8s_node: surface the shadowed backend Message on failure so errors like "resource not enough" are visible instead of a bare retcode
- fix deprecated SDK field usage (MinmalCpuPlatform -> MinimalCpuPlatform)
- new datasource: ucloud_uk8s_images (DescribeUK8SImage)