### PR TITLE
feat: add VPC security group resource and rule resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 FEATURES:
 
+* **New Resource:** `ucloud_sec_group`, manages a VPC security group. Note that it is a different
+  product from `ucloud_security_group`, which manages a firewall.
+* **New Resource:** `ucloud_sec_group_rule`, manages a single ingress or egress rule of a VPC
+  security group.
 * **New Resource:** `ucloud_disk_snapshot`.
 * **New Datasource:** `ucloud_disk_snapshots`.
 * `resource/ucloud_disk`: add `snapshot_id` to create a cloud disk from an existing snapshot.

--- a/ucloud/import_ucloud_sec_group_rule_test.go
+++ b/ucloud/import_ucloud_sec_group_rule_test.go
@@ -1,0 +1,30 @@
+package ucloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccUCloudSecGroupRule_import(t *testing.T) {
+	resourceName := "ucloud_sec_group_rule.foo"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSecGroupRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecGroupRuleConfig,
+			},
+
+			{
+				// the resource id is "<sec_group_id>:<rule_id>", Read parses
+				// sec_group_id back out of it so no ImportStateIdFunc is needed
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/ucloud/import_ucloud_sec_group_test.go
+++ b/ucloud/import_ucloud_sec_group_test.go
@@ -1,0 +1,28 @@
+package ucloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccUCloudSecGroup_import(t *testing.T) {
+	resourceName := "ucloud_sec_group.foo"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSecGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecGroupConfig,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/ucloud/provider.go
+++ b/ucloud/provider.go
@@ -134,6 +134,8 @@ func Provider() terraform.ResourceProvider {
 			"ucloud_disk_attachment":             resourceUCloudDiskAttachment(),
 			"ucloud_disk_snapshot":               resourceUCloudDiskSnapshot(),
 			"ucloud_security_group":              resourceUCloudSecurityGroup(),
+			"ucloud_sec_group":                   resourceUCloudSecGroup(),
+			"ucloud_sec_group_rule":              resourceUCloudSecGroupRule(),
 			"ucloud_lb_ssl":                      resourceUCloudLBSSL(),
 			"ucloud_lb_ssl_attachment":           resourceUCloudLBSSLAttachment(),
 			"ucloud_db_instance":                 resourceUCloudDBInstance(),

--- a/ucloud/resource_ucloud_sec_group.go
+++ b/ucloud/resource_ucloud_sec_group.go
@@ -1,0 +1,278 @@
+package ucloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/ucloud/ucloud-sdk-go/ucloud"
+)
+
+func resourceUCloudSecGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceUCloudSecGroupCreate,
+		Read:   resourceUCloudSecGroupRead,
+		Update: resourceUCloudSecGroupUpdate,
+		Delete: resourceUCloudSecGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateName,
+			},
+
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"tag": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      defaultTag,
+				ValidateFunc: validateTag,
+				StateFunc:    stateFuncTag,
+			},
+
+			"remark": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			// read only view of the rules belong to this sec group, the rules
+			// themselves are managed by the ucloud_sec_group_rule resource
+			"rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"direction": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"protocol_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"dst_port": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"ip_range": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"rule_action": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"priority": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
+						"remark": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"rule_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceUCloudSecGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*UCloudClient)
+	conn := client.vpcconn
+
+	req := conn.NewCreateSecGroupRequest()
+	req.Name = ucloud.String(d.Get("name").(string))
+	req.VPCID = ucloud.String(d.Get("vpc_id").(string))
+
+	resp, err := conn.CreateSecGroup(req)
+	if err != nil {
+		return fmt.Errorf("error on creating sec group, %s", err)
+	}
+
+	d.SetId(resp.SecGroupId)
+
+	// CreateSecGroup accepts neither tag nor remark, both can only be set
+	// afterwards. the tag is always sent so that the remote value matches the
+	// schema default instead of whatever the remote api picks on its own.
+	tag := defaultTag
+	if v, ok := d.GetOk("tag"); ok {
+		tag = v.(string)
+	}
+
+	var remark string
+	if v, ok := d.GetOk("remark"); ok {
+		remark = v.(string)
+	}
+
+	if err := updateSecGroupAttribute(client, d.Id(), d.Get("name").(string), tag, remark); err != nil {
+		return err
+	}
+
+	return resourceUCloudSecGroupRead(d, meta)
+}
+
+func resourceUCloudSecGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*UCloudClient)
+
+	d.Partial(true)
+
+	if !d.IsNewResource() && (d.HasChange("name") || d.HasChange("tag") || d.HasChange("remark")) {
+		// if tag is empty string, use default tag
+		tag := defaultTag
+		if v, ok := d.GetOk("tag"); ok {
+			tag = v.(string)
+		}
+
+		if err := updateSecGroupAttribute(client, d.Id(), d.Get("name").(string), tag, d.Get("remark").(string)); err != nil {
+			return err
+		}
+
+		d.SetPartial("name")
+		d.SetPartial("tag")
+		d.SetPartial("remark")
+	}
+
+	d.Partial(false)
+
+	return resourceUCloudSecGroupRead(d, meta)
+}
+
+func resourceUCloudSecGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*UCloudClient)
+
+	sgSet, err := client.describeSecGroupById(d.Id())
+	if err != nil {
+		if isNotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error on reading sec group %q, %s", d.Id(), err)
+	}
+
+	d.Set("name", sgSet.Name)
+	d.Set("vpc_id", sgSet.VPCId)
+	d.Set("tag", sgSet.Tag)
+	d.Set("remark", sgSet.Remark)
+	d.Set("type", sgSet.Type)
+	d.Set("create_time", timestampToString(sgSet.CreateTime))
+
+	rules := []map[string]interface{}{}
+	for _, item := range sgSet.Rule {
+		rules = append(rules, map[string]interface{}{
+			"direction":     item.Direction,
+			"protocol_type": item.ProtocolType,
+			"dst_port":      item.DstPort,
+			"ip_range":      item.IPRange,
+			"rule_action":   item.RuleAction,
+			"priority":      item.Priority,
+			"remark":        item.Remark,
+			"rule_id":       item.RuleId,
+		})
+	}
+
+	if err := d.Set("rules", rules); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceUCloudSecGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*UCloudClient)
+	conn := client.vpcconn
+
+	req := conn.NewDeleteSecGroupRequest()
+	req.SecGroupId = []string{d.Id()}
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		// the sec group can not be deleted while it is still bound to any
+		// resource, and the unbinding takes a while to take effect, so the
+		// failure is treated as retryable
+		if _, err := conn.DeleteSecGroup(req); err != nil {
+			return resource.RetryableError(fmt.Errorf("error on deleting sec group %q, %s", d.Id(), err))
+		}
+
+		_, err := client.describeSecGroupById(d.Id())
+		if err != nil {
+			if isNotFoundError(err) {
+				return nil
+			}
+			return resource.NonRetryableError(fmt.Errorf("error on reading sec group when deleting %q, %s", d.Id(), err))
+		}
+
+		return resource.RetryableError(fmt.Errorf("the specified sec group %q has not been deleted due to unknown error", d.Id()))
+	})
+}
+
+// UpdateSecGroupRequest.SecGroupId is defined as *string by the sdk while the
+// api backend expects a string array, and the sdk request carries no Tag field
+// at all even though its own comment lists Tag as one of the accepted values,
+// so the request is built by hand.
+// the api requires at least one of Name, Tag and Remark to be set, and it
+// ignores an empty value instead of clearing the field.
+func updateSecGroupAttribute(client *UCloudClient, secGroupId, name, tag, remark string) error {
+	if name == "" && tag == "" && remark == "" {
+		return nil
+	}
+
+	payload := map[string]interface{}{
+		"Action":     "UpdateSecGroup",
+		"SecGroupId": []string{secGroupId},
+	}
+
+	if name != "" {
+		payload["Name"] = name
+	}
+
+	if tag != "" {
+		payload["Tag"] = tag
+	}
+
+	if remark != "" {
+		payload["Remark"] = remark
+	}
+
+	req := client.genericClient.NewGenericRequest()
+	if err := req.SetPayload(payload); err != nil {
+		return fmt.Errorf("error on setting payload for %s to sec group %q, %s", "UpdateSecGroup", secGroupId, err)
+	}
+
+	if _, err := client.genericClient.GenericInvoke(req); err != nil {
+		return fmt.Errorf("error on %s to sec group %q, %s", "UpdateSecGroup", secGroupId, err)
+	}
+
+	return nil
+}

--- a/ucloud/resource_ucloud_sec_group_rule.go
+++ b/ucloud/resource_ucloud_sec_group_rule.go
@@ -1,0 +1,240 @@
+package ucloud
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/ucloud/ucloud-sdk-go/services/vpc"
+	"github.com/ucloud/ucloud-sdk-go/ucloud"
+)
+
+func resourceUCloudSecGroupRule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceUCloudSecGroupRuleCreate,
+		Read:   resourceUCloudSecGroupRuleRead,
+		Update: resourceUCloudSecGroupRuleUpdate,
+		Delete: resourceUCloudSecGroupRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"sec_group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"direction": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"Ingress",
+					"Egress",
+				}, false),
+			},
+
+			"protocol_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"TCP",
+					"UDP",
+					"ICMP",
+					"ICMPv6",
+					"ALL",
+				}, false),
+			},
+
+			"dst_port": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"ip_range": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"rule_action": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"Accept",
+					"Drop",
+				}, false),
+			},
+
+			"priority": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntBetween(1, 200),
+			},
+
+			"remark": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+		},
+	}
+}
+
+func resourceUCloudSecGroupRuleCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*UCloudClient)
+	conn := client.vpcconn
+
+	secGroupId := d.Get("sec_group_id").(string)
+
+	// the rules of one sec group are written one by one, serialize them so
+	// that parallel applies do not race on the same sec group
+	ucloudMutexKV.Lock(secGroupId)
+	defer ucloudMutexKV.Unlock(secGroupId)
+
+	req := conn.NewCreateSecGroupRuleRequest()
+	req.SecGroupId = ucloud.String(secGroupId)
+	req.Rule = []vpc.CreateSecGroupRuleParamRule{
+		{
+			Direction:    ucloud.String(d.Get("direction").(string)),
+			ProtocolType: ucloud.String(d.Get("protocol_type").(string)),
+			DstPort:      ucloud.String(d.Get("dst_port").(string)),
+			IPRange:      ucloud.String(d.Get("ip_range").(string)),
+			RuleAction:   ucloud.String(d.Get("rule_action").(string)),
+			Priority:     ucloud.Int(d.Get("priority").(int)),
+			Remark:       ucloud.String(d.Get("remark").(string)),
+		},
+	}
+
+	resp, err := conn.CreateSecGroupRule(req)
+	if err != nil {
+		return fmt.Errorf("error on creating sec group rule for %q, %s", secGroupId, err)
+	}
+
+	if len(resp.RuleId) < 1 {
+		return fmt.Errorf("error on creating sec group rule for %q, no rule id returned", secGroupId)
+	}
+
+	d.SetId(buildUCloudSecGroupRuleID(secGroupId, resp.RuleId[0]))
+
+	return resourceUCloudSecGroupRuleRead(d, meta)
+}
+
+func resourceUCloudSecGroupRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*UCloudClient)
+	conn := client.vpcconn
+
+	secGroupId, ruleId, err := parseUCloudSecGroupRuleID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	ucloudMutexKV.Lock(secGroupId)
+	defer ucloudMutexKV.Unlock(secGroupId)
+
+	// UpdateSecGroupRule requires every field of the rule, so the whole rule is
+	// sent on any change instead of a per field diff
+	req := conn.NewUpdateSecGroupRuleRequest()
+	req.SecGroupId = ucloud.String(secGroupId)
+	req.Rule = []vpc.UpdateSecGroupRuleParamRule{
+		{
+			RuleId:       ucloud.String(ruleId),
+			Direction:    ucloud.String(d.Get("direction").(string)),
+			ProtocolType: ucloud.String(d.Get("protocol_type").(string)),
+			DstPort:      ucloud.String(d.Get("dst_port").(string)),
+			IPRange:      ucloud.String(d.Get("ip_range").(string)),
+			RuleAction:   ucloud.String(d.Get("rule_action").(string)),
+			Priority:     ucloud.Int(d.Get("priority").(int)),
+			Remark:       ucloud.String(d.Get("remark").(string)),
+		},
+	}
+
+	if _, err := conn.UpdateSecGroupRule(req); err != nil {
+		return fmt.Errorf("error on %s to sec group rule %q, %s", "UpdateSecGroupRule", d.Id(), err)
+	}
+
+	return resourceUCloudSecGroupRuleRead(d, meta)
+}
+
+func resourceUCloudSecGroupRuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*UCloudClient)
+
+	secGroupId, ruleId, err := parseUCloudSecGroupRuleID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	ruleSet, err := client.describeSecGroupRuleById(secGroupId, ruleId)
+	if err != nil {
+		if isNotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error on reading sec group rule %q, %s", d.Id(), err)
+	}
+
+	d.Set("sec_group_id", secGroupId)
+	d.Set("direction", ruleSet.Direction)
+	d.Set("protocol_type", ruleSet.ProtocolType)
+	d.Set("dst_port", ruleSet.DstPort)
+	d.Set("ip_range", ruleSet.IPRange)
+	d.Set("rule_action", ruleSet.RuleAction)
+	d.Set("priority", ruleSet.Priority)
+	d.Set("remark", ruleSet.Remark)
+
+	return nil
+}
+
+func resourceUCloudSecGroupRuleDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*UCloudClient)
+	conn := client.vpcconn
+
+	secGroupId, ruleId, err := parseUCloudSecGroupRuleID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	ucloudMutexKV.Lock(secGroupId)
+	defer ucloudMutexKV.Unlock(secGroupId)
+
+	req := conn.NewDeleteSecGroupRuleRequest()
+	req.SecGroupId = ucloud.String(secGroupId)
+	req.RuleId = []string{ruleId}
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		if _, err := conn.DeleteSecGroupRule(req); err != nil {
+			return resource.NonRetryableError(fmt.Errorf("error on deleting sec group rule %q, %s", d.Id(), err))
+		}
+
+		_, err := client.describeSecGroupRuleById(secGroupId, ruleId)
+		if err != nil {
+			if isNotFoundError(err) {
+				return nil
+			}
+			return resource.NonRetryableError(fmt.Errorf("error on reading sec group rule when deleting %q, %s", d.Id(), err))
+		}
+
+		return resource.RetryableError(fmt.Errorf("the specified sec group rule %q has not been deleted due to unknown error", d.Id()))
+	})
+}
+
+const ucloudSecGroupRuleIDSeparator = ":"
+
+func buildUCloudSecGroupRuleID(secGroupId, ruleId string) string {
+	return strings.Join([]string{secGroupId, ruleId}, ucloudSecGroupRuleIDSeparator)
+}
+
+func parseUCloudSecGroupRuleID(id string) (secGroupId string, ruleId string, err error) {
+	items := strings.Split(id, ucloudSecGroupRuleIDSeparator)
+	if len(items) != 2 || items[0] == "" || items[1] == "" {
+		return "", "", fmt.Errorf(
+			"invalid sec group rule id %q, expected %q",
+			id, "<sec_group_id>"+ucloudSecGroupRuleIDSeparator+"<rule_id>",
+		)
+	}
+
+	return items[0], items[1], nil
+}

--- a/ucloud/resource_ucloud_sec_group_rule_test.go
+++ b/ucloud/resource_ucloud_sec_group_rule_test.go
@@ -1,0 +1,182 @@
+package ucloud
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/ucloud/ucloud-sdk-go/services/vpc"
+)
+
+func TestAccUCloudSecGroupRule_basic(t *testing.T) {
+	var ruleSet vpc.SecGroupRuleInfo
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		IDRefreshName: "ucloud_sec_group_rule.foo",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckSecGroupRuleDestroy,
+
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecGroupRuleConfig,
+
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecGroupRuleExists("ucloud_sec_group_rule.foo", &ruleSet),
+					testAccCheckSecGroupRuleAttributes(&ruleSet),
+					resource.TestCheckResourceAttr("ucloud_sec_group_rule.foo", "direction", "Ingress"),
+					resource.TestCheckResourceAttr("ucloud_sec_group_rule.foo", "protocol_type", "TCP"),
+					resource.TestCheckResourceAttr("ucloud_sec_group_rule.foo", "dst_port", "22"),
+					resource.TestCheckResourceAttr("ucloud_sec_group_rule.foo", "ip_range", "192.168.0.0/16"),
+					resource.TestCheckResourceAttr("ucloud_sec_group_rule.foo", "rule_action", "Accept"),
+					resource.TestCheckResourceAttr("ucloud_sec_group_rule.foo", "priority", "50"),
+					resource.TestCheckResourceAttr("ucloud_sec_group_rule.foo", "remark", "ssh"),
+					resource.TestCheckResourceAttrSet("ucloud_sec_group_rule.foo", "sec_group_id"),
+				),
+			},
+
+			{
+				// every field but sec_group_id is updated in place through
+				// UpdateSecGroupRule, the rule id must stay the same
+				Config: testAccSecGroupRuleConfigTwo,
+
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecGroupRuleExists("ucloud_sec_group_rule.foo", &ruleSet),
+					testAccCheckSecGroupRuleAttributes(&ruleSet),
+					resource.TestCheckResourceAttr("ucloud_sec_group_rule.foo", "direction", "Ingress"),
+					resource.TestCheckResourceAttr("ucloud_sec_group_rule.foo", "protocol_type", "TCP"),
+					resource.TestCheckResourceAttr("ucloud_sec_group_rule.foo", "dst_port", "3306"),
+					resource.TestCheckResourceAttr("ucloud_sec_group_rule.foo", "ip_range", "192.168.1.0/24"),
+					resource.TestCheckResourceAttr("ucloud_sec_group_rule.foo", "rule_action", "Drop"),
+					resource.TestCheckResourceAttr("ucloud_sec_group_rule.foo", "priority", "100"),
+					resource.TestCheckResourceAttr("ucloud_sec_group_rule.foo", "remark", "mysql"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSecGroupRuleExists(n string, ruleSet *vpc.SecGroupRuleInfo) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("sec group rule id is empty")
+		}
+
+		secGroupId, ruleId, err := parseUCloudSecGroupRuleID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		client := testAccProvider.Meta().(*UCloudClient)
+		ptr, err := client.describeSecGroupRuleById(secGroupId, ruleId)
+
+		log.Printf("[INFO] sec group rule id %#v", rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		*ruleSet = *ptr
+		return nil
+	}
+}
+
+func testAccCheckSecGroupRuleAttributes(ruleSet *vpc.SecGroupRuleInfo) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if ruleSet.RuleId == "" {
+			return fmt.Errorf("sec group rule id is empty")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSecGroupRuleDestroy(s *terraform.State) error {
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ucloud_sec_group_rule" {
+			continue
+		}
+
+		secGroupId, ruleId, err := parseUCloudSecGroupRuleID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		client := testAccProvider.Meta().(*UCloudClient)
+		d, err := client.describeSecGroupRuleById(secGroupId, ruleId)
+
+		// Verify the error is what we want
+		if err != nil {
+			if isNotFoundError(err) {
+				continue
+			}
+			return err
+		}
+
+		if d.RuleId != "" {
+			return fmt.Errorf("sec group rule still exist")
+		}
+	}
+
+	return nil
+}
+
+const testAccSecGroupRuleConfig = `
+resource "ucloud_vpc" "foo" {
+	name        = "tf-acc-sec-group-rule"
+	tag         = "tf-acc"
+	cidr_blocks = ["192.168.0.0/16"]
+}
+
+resource "ucloud_sec_group" "foo" {
+	name   = "tf-acc-sec-group-rule"
+	vpc_id = "${ucloud_vpc.foo.id}"
+}
+
+resource "ucloud_sec_group_rule" "foo" {
+	sec_group_id  = "${ucloud_sec_group.foo.id}"
+	direction     = "Ingress"
+	protocol_type = "TCP"
+	dst_port      = "22"
+	ip_range      = "192.168.0.0/16"
+	rule_action   = "Accept"
+	priority      = 50
+	remark        = "ssh"
+}
+`
+
+const testAccSecGroupRuleConfigTwo = `
+resource "ucloud_vpc" "foo" {
+	name        = "tf-acc-sec-group-rule"
+	tag         = "tf-acc"
+	cidr_blocks = ["192.168.0.0/16"]
+}
+
+resource "ucloud_sec_group" "foo" {
+	name   = "tf-acc-sec-group-rule"
+	vpc_id = "${ucloud_vpc.foo.id}"
+}
+
+resource "ucloud_sec_group_rule" "foo" {
+	sec_group_id  = "${ucloud_sec_group.foo.id}"
+	direction     = "Ingress"
+	protocol_type = "TCP"
+	dst_port      = "3306"
+	ip_range      = "192.168.1.0/24"
+	rule_action   = "Drop"
+	priority      = 100
+	remark        = "mysql"
+}
+`

--- a/ucloud/resource_ucloud_sec_group_test.go
+++ b/ucloud/resource_ucloud_sec_group_test.go
@@ -1,0 +1,149 @@
+package ucloud
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/ucloud/ucloud-sdk-go/services/vpc"
+)
+
+func TestAccUCloudSecGroup_basic(t *testing.T) {
+	var sgSet vpc.SecGroupInfo
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		IDRefreshName: "ucloud_sec_group.foo",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckSecGroupDestroy,
+
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecGroupConfig,
+
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecGroupExists("ucloud_sec_group.foo", &sgSet),
+					testAccCheckSecGroupAttributes(&sgSet),
+					resource.TestCheckResourceAttr("ucloud_sec_group.foo", "name", "tf-acc-sec-group"),
+					resource.TestCheckResourceAttr("ucloud_sec_group.foo", "tag", "tf-acc"),
+					resource.TestCheckResourceAttr("ucloud_sec_group.foo", "remark", "acceptance test"),
+					resource.TestCheckResourceAttrSet("ucloud_sec_group.foo", "vpc_id"),
+					resource.TestCheckResourceAttrSet("ucloud_sec_group.foo", "create_time"),
+				),
+			},
+
+			{
+				Config: testAccSecGroupConfigTwo,
+
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecGroupExists("ucloud_sec_group.foo", &sgSet),
+					testAccCheckSecGroupAttributes(&sgSet),
+					resource.TestCheckResourceAttr("ucloud_sec_group.foo", "name", "tf-acc-sec-group-two"),
+					// tag is omitted by the second config, it must fall back to the default
+					resource.TestCheckResourceAttr("ucloud_sec_group.foo", "tag", defaultTag),
+					resource.TestCheckResourceAttr("ucloud_sec_group.foo", "remark", "acceptance test updated"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSecGroupExists(n string, sgSet *vpc.SecGroupInfo) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("sec group id is empty")
+		}
+
+		client := testAccProvider.Meta().(*UCloudClient)
+		ptr, err := client.describeSecGroupById(rs.Primary.ID)
+
+		log.Printf("[INFO] sec group id %#v", rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		*sgSet = *ptr
+		return nil
+	}
+}
+
+func testAccCheckSecGroupAttributes(sgSet *vpc.SecGroupInfo) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if sgSet.SecGroupId == "" {
+			return fmt.Errorf("sec group id is empty")
+		}
+
+		if sgSet.VPCId == "" {
+			return fmt.Errorf("sec group %q is expected to belong to a vpc", sgSet.SecGroupId)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSecGroupDestroy(s *terraform.State) error {
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ucloud_sec_group" {
+			continue
+		}
+
+		client := testAccProvider.Meta().(*UCloudClient)
+		d, err := client.describeSecGroupById(rs.Primary.ID)
+
+		// Verify the error is what we want
+		if err != nil {
+			if isNotFoundError(err) {
+				continue
+			}
+			return err
+		}
+
+		if d.SecGroupId != "" {
+			return fmt.Errorf("sec group still exist")
+		}
+	}
+
+	return nil
+}
+
+const testAccSecGroupConfig = `
+resource "ucloud_vpc" "foo" {
+	name        = "tf-acc-sec-group"
+	tag         = "tf-acc"
+	cidr_blocks = ["192.168.0.0/16"]
+}
+
+resource "ucloud_sec_group" "foo" {
+	name   = "tf-acc-sec-group"
+	vpc_id = "${ucloud_vpc.foo.id}"
+	tag    = "tf-acc"
+	remark = "acceptance test"
+}
+`
+
+const testAccSecGroupConfigTwo = `
+resource "ucloud_vpc" "foo" {
+	name        = "tf-acc-sec-group"
+	tag         = "tf-acc"
+	cidr_blocks = ["192.168.0.0/16"]
+}
+
+resource "ucloud_sec_group" "foo" {
+	name   = "tf-acc-sec-group-two"
+	vpc_id = "${ucloud_vpc.foo.id}"
+	remark = "acceptance test updated"
+}
+`

--- a/ucloud/service_ucloud_sec_group.go
+++ b/ucloud/service_ucloud_sec_group.go
@@ -5,7 +5,12 @@ import (
 
 	"github.com/ucloud/ucloud-sdk-go/services/vpc"
 	"github.com/ucloud/ucloud-sdk-go/ucloud"
+	uerr "github.com/ucloud/ucloud-sdk-go/ucloud/error"
 )
+
+// DescribeSecGroup answers a missing sec group with this error code instead of
+// an empty result set, eg. "describe secgroup error: secgroup-xxx not exist in VPC()"
+const secGroupNotExistCode = 208704
 
 func (c *UCloudClient) describeSecGroupsByVPCId(vpcId string) ([]vpc.SecGroupInfo, error) {
 	conn := c.vpcconn
@@ -63,4 +68,55 @@ func (c *UCloudClient) describeResourceSecGroup(resourceId string) ([]vpc.Bindin
 	}
 
 	return resp.DataSet[0].SecGroupInfo, nil
+}
+
+func (c *UCloudClient) describeSecGroupById(secGroupId string) (*vpc.SecGroupInfo, error) {
+	if secGroupId == "" {
+		return nil, newNotFoundError(getNotFoundMessage("sec group", secGroupId))
+	}
+
+	conn := c.vpcconn
+
+	req := conn.NewDescribeSecGroupRequest()
+	req.SecGroupId = []string{secGroupId}
+
+	resp, err := conn.DescribeSecGroup(req)
+	if err != nil {
+		if uErr, ok := err.(uerr.Error); ok && uErr.Code() == secGroupNotExistCode {
+			return nil, newNotFoundError(getNotFoundMessage("sec group", secGroupId))
+		}
+		return nil, err
+	}
+	if resp.GetRetCode() != 0 {
+		if resp.GetRetCode() == secGroupNotExistCode {
+			return nil, newNotFoundError(getNotFoundMessage("sec group", secGroupId))
+		}
+		return nil, fmt.Errorf("error on reading sec group %q, %s", secGroupId, resp.GetMessage())
+	}
+	if len(resp.DataSet) < 1 {
+		return nil, newNotFoundError(getNotFoundMessage("sec group", secGroupId))
+	}
+
+	return &resp.DataSet[0], nil
+}
+
+// there is no api to describe a single sec group rule, so we read the whole
+// sec group and pick the rule out of it by rule id
+func (c *UCloudClient) describeSecGroupRuleById(secGroupId, ruleId string) (*vpc.SecGroupRuleInfo, error) {
+	if secGroupId == "" || ruleId == "" {
+		return nil, newNotFoundError(getNotFoundMessage("sec group rule", ruleId))
+	}
+
+	sgSet, err := c.describeSecGroupById(secGroupId)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range sgSet.Rule {
+		if sgSet.Rule[i].RuleId == ruleId {
+			return &sgSet.Rule[i], nil
+		}
+	}
+
+	return nil, newNotFoundError(getNotFoundMessage("sec group rule", ruleId))
 }

--- a/website/docs/r/sec_group.html.markdown
+++ b/website/docs/r/sec_group.html.markdown
@@ -1,0 +1,95 @@
+---
+subcategory: "VPC"
+layout: "ucloud"
+page_title: "UCloud: ucloud_sec_group"
+description: |-
+  Provides a Security Group (SecGroup) resource.
+---
+
+# ucloud_sec_group
+
+Provides a Security Group (SecGroup) resource in a VPC.
+
+~> **Note** `ucloud_sec_group` and `ucloud_security_group` are two different products. `ucloud_sec_group` is the VPC security group, while `ucloud_security_group` is the firewall. They are not interchangeable, and a resource created by one of them can not be managed by the other.
+
+~> **Note** The rules of a security group are managed by the separate [`ucloud_sec_group_rule`](/docs/providers/ucloud/r/sec_group_rule.html) resource. The `rules` attribute exported here is read only, it is a snapshot of the rules that currently belong to the group, including the ones created outside of terraform.
+
+## Example Usage
+
+```hcl
+resource "ucloud_vpc" "example" {
+  name        = "tf-example-vpc"
+  cidr_blocks = ["192.168.0.0/16"]
+}
+
+resource "ucloud_sec_group" "example" {
+  name   = "tf-example-sec-group"
+  vpc_id = ucloud_vpc.example.id
+  tag    = "tf-example"
+  remark = "managed by terraform"
+}
+
+resource "ucloud_sec_group_rule" "ssh" {
+  sec_group_id  = ucloud_sec_group.example.id
+  direction     = "Ingress"
+  protocol_type = "TCP"
+  dst_port      = "22"
+  ip_range      = "192.168.0.0/16"
+  rule_action   = "Accept"
+  priority      = 50
+}
+```
+
+Bind the security group to an instance:
+
+```hcl
+resource "ucloud_instance" "example" {
+  # ... other configuration ...
+
+  security_mode = "SecGroup"
+
+  sec_group_id {
+    id       = ucloud_sec_group.example.id
+    priority = 1
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the security group, should have 1-63 characters and only support Chinese, English, numbers, '-', '_', '.'.
+* `vpc_id` - (Required, ForceNew) The ID of the VPC that the security group belongs to. The remote api does not support moving a security group between VPCs, so any change of it will destroy the existing security group and create a new one.
+
+- - -
+
+* `tag` - (Optional) A tag assigned to the security group, which contains at most 63 characters and only support Chinese, English, numbers, '-', '_', and '.'. If it is not filled in or a empty string is filled in, then default tag will be assigned. (Default: `Default`).
+* `remark` - (Optional) The remarks of the security group. The remote api ignores an empty value instead of clearing the field, so an existing remark can be replaced but not removed.
+
+~> **Note** The remote api accepts neither `tag` nor `remark` while the security group is being created, both are applied right after the creation. A failure in that second step leaves the security group tainted, and the next apply recreates it.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the security group.
+* `type` - The type of the security group. Possible values are: `user defined` as a user defined security group, `recommend web` as a security group created from the web template, `recommend non web` as a security group created from the non web template.
+* `create_time` - The time of creation, formatted in RFC3339 time string.
+* `rules` - A read only list of the rules that currently belong to the security group. Each element contains the following attributes:
+    * `rule_id` - The ID of the rule.
+    * `direction` - The direction of the rule. Possible values are: `Ingress`, `Egress`.
+    * `protocol_type` - The protocol type of the rule. Possible values are: `TCP`, `UDP`, `ICMP`, `ICMPv6`, `ALL`.
+    * `dst_port` - The destination port of the rule.
+    * `ip_range` - The IP address range of the rule.
+    * `rule_action` - The action of the rule. Possible values are: `Accept`, `Drop`.
+    * `priority` - The priority of the rule.
+    * `remark` - The remarks of the rule.
+
+## Import
+
+Security group can be imported using the `id`, e.g.
+
+```
+$ terraform import ucloud_sec_group.example secgroup-abcdefg
+```

--- a/website/docs/r/sec_group_rule.html.markdown
+++ b/website/docs/r/sec_group_rule.html.markdown
@@ -1,0 +1,101 @@
+---
+subcategory: "VPC"
+layout: "ucloud"
+page_title: "UCloud: ucloud_sec_group_rule"
+description: |-
+  Provides a Security Group (SecGroup) rule resource.
+---
+
+# ucloud_sec_group_rule
+
+Provides a rule of a Security Group (SecGroup). Each resource represents a single ingress or egress rule of the security group referenced by `sec_group_id`.
+
+~> **Note** This resource only manages the rules it declares. Rules added to the same security group outside of terraform are left untouched, they show up in the read only `rules` attribute of [`ucloud_sec_group`](/docs/providers/ucloud/r/sec_group.html).
+
+~> **Note** This resource belongs to the VPC security group, not to the firewall. The rules of a firewall are declared inline in the `rules` block of `ucloud_security_group`, and the two are not interchangeable.
+
+## Example Usage
+
+```hcl
+resource "ucloud_vpc" "example" {
+  name        = "tf-example-vpc"
+  cidr_blocks = ["192.168.0.0/16"]
+}
+
+resource "ucloud_sec_group" "example" {
+  name   = "tf-example-sec-group"
+  vpc_id = ucloud_vpc.example.id
+}
+
+resource "ucloud_sec_group_rule" "ssh" {
+  sec_group_id  = ucloud_sec_group.example.id
+  direction     = "Ingress"
+  protocol_type = "TCP"
+  dst_port      = "22"
+  ip_range      = "192.168.0.0/16"
+  rule_action   = "Accept"
+  priority      = 50
+  remark        = "ssh from intranet"
+}
+```
+
+Generate several rules from a map:
+
+```hcl
+variable "ingress_rules" {
+  type = map(object({
+    dst_port = string
+    ip_range = string
+    priority = number
+  }))
+
+  default = {
+    http  = { dst_port = "80", ip_range = "0.0.0.0/0", priority = 50 }
+    https = { dst_port = "443", ip_range = "0.0.0.0/0", priority = 50 }
+    mysql = { dst_port = "3306", ip_range = "192.168.0.0/16", priority = 60 }
+  }
+}
+
+resource "ucloud_sec_group_rule" "ingress" {
+  for_each = var.ingress_rules
+
+  sec_group_id  = ucloud_sec_group.example.id
+  direction     = "Ingress"
+  protocol_type = "TCP"
+  dst_port      = each.value.dst_port
+  ip_range      = each.value.ip_range
+  rule_action   = "Accept"
+  priority      = each.value.priority
+  remark        = each.key
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `sec_group_id` - (Required, ForceNew) The ID of the security group that the rule belongs to. A rule can not be moved between security groups, so any change of it will destroy the existing rule and create a new one.
+* `direction` - (Required) The direction of the rule. Possible values are: `Ingress` as an inbound rule, `Egress` as an outbound rule.
+* `protocol_type` - (Required) The protocol type of the rule. Possible values are: `TCP`, `UDP`, `ICMP`, `ICMPv6`, `ALL`.
+* `dst_port` - (Required) The destination port of the rule, separated by commas. Such as: `80`, `80,443`, `443,2000-10000`.
+* `ip_range` - (Required) The IP address range of the rule, separated by commas. Such as: `0.0.0.0/0`, `192.168.0.0/16`.
+* `rule_action` - (Required) The action taken when the rule matches. Possible values are: `Accept`, `Drop`.
+* `priority` - (Required) The priority of the rule, ranges from 1 to 200.
+
+- - -
+
+* `remark` - (Optional) The remarks of the rule. Defaults to an empty string.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the rule, formatted as `<sec_group_id>:<rule_id>`.
+
+## Import
+
+Security group rule can be imported using the `id`, e.g.
+
+```
+$ terraform import ucloud_sec_group_rule.example secgroup-abcdefg:sgrule-hijklmn
+```


### PR DESCRIPTION
## Background

Demand 2138552 (P1, customer request). The provider could already query security groups (`ucloud_sec_groups`) and bind them to instances (`ucloud_instance.security_mode` / `sec_group_id`), but there was no way to **create or maintain** one.

Customers hitting this reached for `ucloud_security_group`, which is backed by the UNet `CreateFirewall` API and manages a **firewall**, not a VPC security group. They got a resource that does not do what they asked for.

A `ucloud_sec_group` resource was written during #172 and removed again in the same PR, on the assumption that security groups are created in the console and terraform only needs to query and bind them. This demand overturns that assumption.

## What this adds

| Resource | Purpose |
| --- | --- |
| `ucloud_sec_group` | The security group itself. Create / Read / Update / Delete / Import |
| `ucloud_sec_group_rule` | A single ingress or egress rule. Create / Read / Update / Delete / Import |

```hcl
resource "ucloud_sec_group" "web" {
  name   = "web-sg"
  vpc_id = ucloud_vpc.main.id
  tag    = "web"
}

resource "ucloud_sec_group_rule" "ssh" {
  sec_group_id  = ucloud_sec_group.web.id
  direction     = "Ingress"
  protocol_type = "TCP"
  dst_port      = "22"
  ip_range      = "10.0.0.0/8"
  rule_action   = "Accept"
  priority      = 50
}
```

## Why rules are a separate resource, not an inline block

- It matches how this provider already models child objects that carry their own server side id: `ucloud_lb_rule` (`PolicyId`), `ucloud_nat_gateway_rule` (`PolicyId`), `ucloud_lb_listener` (`VServerId`). `ucloud_security_group.rules` is inline only because the firewall API has no per rule id and replaces the whole list at once.
- It matches the alicloud provider, which splits `alicloud_security_group` from `alicloud_security_group_rule` and keeps no rules block on the group at all.
- It allows `for_each` over a rule map, which an inline block cannot do.

The `rules` attribute exported by `ucloud_sec_group` is **read only**. It is a snapshot of what the group currently holds, including rules added outside terraform, and it never drives a write. The two resources therefore cannot fight over ownership of a rule, which is the failure mode the AWS provider warns about when inline and standalone rules are mixed.

## Remote API quirks worked around

**1. `DescribeSecGroup` reports a missing group as an error, not an empty result.**

```
RetCode 208704: describe secgroup error: secgroup-xxx not exist in VPC()
```

`describeSecGroupById` maps that code to a not found error. Without it, every `terraform destroy` fails, because the post delete check treats the error as fatal, and a group deleted out of band raises an error instead of being recreated. This was caught only by running the acceptance tests against the real API — the first run failed 4/4 on exactly this.

**2. The SDK's `UpdateSecGroup` request is incomplete.** `SecGroupId` is typed `*string` while the backend expects an array (the SDK's own comment says so), and there is no `Tag` field at all even though the same comment lists `Tag` among the accepted values. Both are handled by building the request through `GenericInvoke`. Confirmed empirically that the backend does accept `Tag`: requests carrying `Tag=tf-acc` returned RetCode 0 and `DescribeSecGroup` read the value back.

**3. `CreateSecGroup` accepts neither `tag` nor `remark`,** so both are applied in a follow up call right after creation. The tag is always sent, even at its default, so the remote value cannot drift from the schema default.

## Concurrency

Terraform applies independent rule resources in parallel. Writes to the rules of one security group are serialized per `sec_group_id` through `ucloudMutexKV`, so parallel applies cannot race on the same group. Rules of different groups still run concurrently. Read paths are not locked.

## Verification

Acceptance tests run against the real API in `cn-bj2`:

```
--- PASS: TestAccUCloudSecGroup_import       (26.37s)
--- PASS: TestAccUCloudSecGroupRule_import   (30.16s)
--- PASS: TestAccUCloudSecGroup_basic        (33.28s)
--- PASS: TestAccUCloudSecGroupRule_basic    (36.25s)
```

Coverage includes creating the group, updating `name` / `tag` / `remark`, creating a rule, updating every rule field but `sec_group_id` in place through `UpdateSecGroupRule`, destroying both, and importing both with `ImportStateVerify: true` (no `ImportStateVerifyIgnore` needed on either resource). `go vet`, `gofmt -s` and `make test` are clean. `vendor/` is untouched.

## Not covered

These paths are not exercised by the acceptance tests and remain unverified:

- `remark` set back to an empty string — the remote API ignores empty values rather than clearing the field
- `dst_port` for `ICMP` / `ALL`, where the port has no meaning but the API marks the field required
- Several rules sharing one `priority`
- The `ucloudMutexKV` path under real concurrency — each test group holds a single rule
