### PR TITLE
fix: 维护者名单变更强制校验 Core 审批

### DIFF
--- a/.github/workflows/product-ownership-review.yml
+++ b/.github/workflows/product-ownership-review.yml
@@ -1,0 +1,15 @@
+name: Product ownership review
+
+on:
+  pull_request_review:
+    types: [submitted, dismissed, edited]
+
+permissions: {}
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      # Only signal the trusted workflow_run handler. No PR code or artifacts
+      # are consumed by the handler, including for fork pull requests.
+      - run: "true"

--- a/.github/workflows/product-ownership.yml
+++ b/.github/workflows/product-ownership.yml
@@ -10,18 +10,59 @@ on:
       - reopened
       - ready_for_review
       - edited
+  workflow_run:
+    workflows: [Product ownership review]
+    types: [completed]
+  workflow_dispatch:
 
 permissions:
   contents: read
   pull-requests: read
   statuses: write
 
-concurrency:
-  group: product-ownership-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
+  resolve:
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request_review') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      pull_requests: ${{ steps.resolve.outputs.pull_requests }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - id: resolve
+        name: Resolve current ownership proposals
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == 'pull_request_target' ]]; then
+            numbers="${EVENT_PR}"
+          else
+            numbers="$(bash scripts/recheck-product-ownership.sh list)"
+          fi
+          matrix="$(printf '%s\n' "${numbers}" | jq -Rsc 'split("\n") | map(select(length > 0) | tonumber)')"
+          printf 'pull_requests=%s\n' "${matrix}" >>"${GITHUB_OUTPUT}"
+
   ownership:
+    needs: resolve
+    if: needs.resolve.outputs.pull_requests != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        pull_request: ${{ fromJSON(needs.resolve.outputs.pull_requests) }}
+    concurrency:
+      group: product-ownership-${{ matrix.pull_request }}
+      cancel-in-progress: false
     name: Enforce product ownership
     timeout-minutes: 5
     runs-on: ubuntu-latest
@@ -37,6 +78,13 @@ jobs:
           go-version: "1.19.5"
           cache: false
       - name: Verify pull request owner and paths
+        if: github.event_name == 'pull_request_target'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: go run ./cmd/product-ownership -config .github/product-owners.json -event "${GITHUB_EVENT_PATH}"
+      - name: Recheck ownership proposals after review
+        if: github.event_name != 'pull_request_target'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PRODUCT_OWNERSHIP_PR: ${{ matrix.pull_request }}
+        run: bash scripts/recheck-product-ownership.sh

--- a/cmd/product-ownership/main_test.go
+++ b/cmd/product-ownership/main_test.go
@@ -15,6 +15,26 @@ import (
 )
 
 func TestRunAuthorizesGeneratedProductOnboardingPolicy(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		reviews string
+		wantErr bool
+	}{
+		{"current core approval", `[{"id":1,"user":{"login":"CoreOwner"},"state":"APPROVED","commit_id":"0123456789abcdef0123456789abcdef01234567"}]`, false},
+		{"no approval", `[]`, true},
+		{"non-core approval", `[{"id":1,"user":{"login":"OldOwner"},"state":"APPROVED","commit_id":"0123456789abcdef0123456789abcdef01234567"}]`, true},
+		{"old commit approval", `[{"id":1,"user":{"login":"CoreOwner"},"state":"APPROVED","commit_id":"89abcdef0123456789abcdef0123456789abcdef"}]`, true},
+		{"dismissed approval", `[{"id":1,"user":{"login":"CoreOwner"},"state":"DISMISSED","commit_id":"0123456789abcdef0123456789abcdef01234567"}]`, true},
+		{"subsequent changes requested", `[{"id":1,"user":{"login":"CoreOwner"},"state":"APPROVED","commit_id":"0123456789abcdef0123456789abcdef01234567"},{"id":2,"user":{"login":"CoreOwner"},"state":"CHANGES_REQUESTED","commit_id":"0123456789abcdef0123456789abcdef01234567"}]`, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			testGeneratedProductOnboardingPolicy(t, test.reviews, test.wantErr)
+		})
+	}
+}
+
+func testGeneratedProductOnboardingPolicy(t *testing.T, reviews string, wantErr bool) {
+	t.Helper()
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, ".github"), 0755); err != nil {
 		t.Fatalf("create policy directory: %v", err)
@@ -48,6 +68,9 @@ func TestRunAuthorizesGeneratedProductOnboardingPolicy(t *testing.T) {
 	contentRequested := false
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		switch {
+		case request.Method == http.MethodGet && strings.HasSuffix(request.URL.Path, "/pulls/42/reviews"):
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(reviews))
 		case request.Method == http.MethodGet && strings.HasSuffix(request.URL.Path, "/pulls/42/files"):
 			writer.Header().Set("Content-Type", "application/json")
 			_, _ = writer.Write([]byte(`[{"filename":".github/product-owners.json","status":"modified"}]`))
@@ -106,6 +129,15 @@ func TestRunAuthorizesGeneratedProductOnboardingPolicy(t *testing.T) {
 		&stderr,
 		getenv,
 	)
+	if wantErr {
+		if err == nil || !strings.Contains(err.Error(), "core approval") {
+			t.Fatalf("run() error = %v, want missing core approval", err)
+		}
+		if got := strings.Join(states, ","); got != "pending,failure" {
+			t.Fatalf("status states = %q, want pending,failure", got)
+		}
+		return
+	}
 	if err != nil {
 		t.Fatalf("run() error = %v, stderr = %s", err, stderr.String())
 	}

--- a/internal/productownership/approval.go
+++ b/internal/productownership/approval.go
@@ -1,0 +1,96 @@
+package productownership
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type pullRequestReview struct {
+	ID       int64  `json:"id"`
+	State    string `json:"state"`
+	CommitID string `json:"commit_id"`
+	User     struct {
+		Login string `json:"login"`
+	} `json:"user"`
+}
+
+// RequireCoreApproval uses only the trusted policy and reviews of the exact
+// proposed commit. New commits and dismissed approvals require a fresh review.
+func (client GitHubClient) RequireCoreApproval(ctx context.Context, event PullRequestEvent, core Owners) error {
+	if strings.TrimSpace(client.BaseURL) == "" || strings.TrimSpace(client.Token) == "" {
+		return fmt.Errorf("core approval requires a GitHub API URL and token")
+	}
+	repository := strings.Split(event.Repository, "/")
+	if len(repository) != 2 || !validRepositoryName(repository[0]) || !validRepositoryName(repository[1]) || event.Number < 1 || !validCommitSHA(event.HeadSHA) {
+		return fmt.Errorf("invalid pull request identity for core approval")
+	}
+	owners, err := normalizeUsers(core.GitHubUsers)
+	if err != nil || len(owners) == 0 {
+		return fmt.Errorf("core approval requires valid trusted core maintainers")
+	}
+	httpClient := client.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	latest := make(map[string]pullRequestReview)
+	for page := 1; page <= 100; page++ {
+		endpoint := strings.TrimRight(client.BaseURL, "/") + "/repos/" +
+			url.PathEscape(repository[0]) + "/" + url.PathEscape(repository[1]) +
+			"/pulls/" + strconv.Itoa(event.Number) + "/reviews?per_page=100&page=" + strconv.Itoa(page)
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return fmt.Errorf("create core approval request: %w", err)
+		}
+		request.Header.Set("Accept", "application/vnd.github+json")
+		request.Header.Set("Authorization", "Bearer "+client.Token)
+		request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+		response, err := httpClient.Do(request)
+		if err != nil {
+			return fmt.Errorf("request core approval reviews: %w", err)
+		}
+		if response.StatusCode != http.StatusOK {
+			_ = response.Body.Close()
+			return fmt.Errorf("core approval reviews returned %s", response.Status)
+		}
+		var reviews []pullRequestReview
+		decodeErr := json.NewDecoder(io.LimitReader(response.Body, 16<<20)).Decode(&reviews)
+		closeErr := response.Body.Close()
+		if decodeErr != nil {
+			return fmt.Errorf("decode core approval reviews: %w", decodeErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close core approval reviews: %w", closeErr)
+		}
+		for _, review := range reviews {
+			login := normalizeUser(review.User.Login)
+			if !contains(owners, login) || login == normalizeUser(event.Author) {
+				continue
+			}
+			// Comments and pending reviews do not replace a submitted decision.
+			if review.State == "COMMENTED" || review.State == "PENDING" {
+				continue
+			}
+			if review.ID <= 0 {
+				return fmt.Errorf("core approval review has an invalid ID")
+			}
+			if previous, exists := latest[login]; !exists || review.ID > previous.ID {
+				latest[login] = review
+			}
+		}
+		if len(reviews) < 100 {
+			for _, review := range latest {
+				if review.State == "APPROVED" && review.CommitID == event.HeadSHA {
+					return nil
+				}
+			}
+			return fmt.Errorf("product ownership changes require core approval of commit %s", event.HeadSHA)
+		}
+	}
+	return fmt.Errorf("core approval review pagination exceeded 100 pages")
+}

--- a/internal/productownership/approval_test.go
+++ b/internal/productownership/approval_test.go
@@ -1,0 +1,84 @@
+package productownership_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-ucloud/internal/productownership"
+)
+
+func TestCoreApprovalReadsAllPagesBeforeAccepting(t *testing.T) {
+	head := strings.Repeat("a", 40)
+	for _, test := range []struct {
+		name  string
+		state string
+		allow bool
+	}{
+		{"approval after first page", "APPROVED", true},
+		{"later dismissal", "DISMISSED", false},
+		{"later rejection", "CHANGES_REQUESTED", false},
+		{"comment preserves approval", "COMMENTED", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			pages := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				pages++
+				if r.Header.Get("Authorization") != "Bearer test-token" || r.URL.Path != "/repos/ucloud/terraform-provider-ucloud/pulls/42/reviews" {
+					t.Errorf("unexpected review request: %s", r.URL)
+				}
+				review := func(id int, login, state string) map[string]interface{} {
+					return map[string]interface{}{"id": id, "user": map[string]string{"login": login}, "state": state, "commit_id": head}
+				}
+				var reviews []map[string]interface{}
+				switch r.URL.Query().Get("page") {
+				case "1":
+					for i := 1; i <= 100; i++ {
+						reviews = append(reviews, review(i, "OtherUser", "COMMENTED"))
+					}
+					if test.state != "APPROVED" {
+						reviews[0] = review(1, "COREOWNER", "APPROVED")
+					}
+				case "2":
+					reviews = []map[string]interface{}{review(101, "CoreOwner", test.state)}
+				default:
+					t.Errorf("unexpected page: %s", r.URL)
+				}
+				_ = json.NewEncoder(w).Encode(reviews)
+			}))
+			defer server.Close()
+			client := productownership.GitHubClient{BaseURL: server.URL, Token: "test-token", HTTPClient: server.Client()}
+			err := client.RequireCoreApproval(context.Background(), productownership.PullRequestEvent{
+				Repository: "ucloud/terraform-provider-ucloud", Number: 42, Author: "NewOwner", HeadSHA: head,
+			}, productownership.Owners{GitHubUsers: []string{"CoreOwner"}})
+			if (err == nil) != test.allow {
+				t.Fatalf("RequireCoreApproval() = %v, want allowed=%t", err, test.allow)
+			}
+			if pages != 2 {
+				t.Fatalf("read %d pages, want 2", pages)
+			}
+		})
+	}
+}
+
+func TestCoreApprovalFailsClosedOnAPIError(t *testing.T) {
+	for _, status := range []int{http.StatusForbidden, http.StatusInternalServerError, http.StatusOK} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte("invalid JSON"))
+			}))
+			defer server.Close()
+			client := productownership.GitHubClient{BaseURL: server.URL, Token: "test-token", HTTPClient: server.Client()}
+			err := client.RequireCoreApproval(context.Background(), productownership.PullRequestEvent{
+				Repository: "ucloud/terraform-provider-ucloud", Number: 42, Author: "NewOwner", HeadSHA: strings.Repeat("a", 40),
+			}, productownership.Owners{GitHubUsers: []string{"CoreOwner"}})
+			if err == nil {
+				t.Fatal("API failure must not authorize an ownership change")
+			}
+		})
+	}
+}

--- a/internal/productownership/gate.go
+++ b/internal/productownership/gate.go
@@ -49,11 +49,13 @@ func (gate Gate) Run(ctx context.Context, event PullRequestEvent) (GateResult, e
 	}
 	if checkErr != nil && gate.OnboardingAuthorizer != nil && isOnboardingPolicyChange(changes) {
 		decision, checkErr = gate.OnboardingAuthorizer(ctx, event)
-		onboardingAuthorized = checkErr == nil
 		if checkErr == nil && decision.Owner == "" {
 			checkErr = fmt.Errorf("product onboarding authorizer returned an empty owner")
-			onboardingAuthorized = false
 		}
+		if checkErr == nil {
+			checkErr = gate.GitHub.RequireCoreApproval(ctx, event, gate.Policy.Core)
+		}
+		onboardingAuthorized = checkErr == nil
 	}
 	if checkErr == nil && !onboardingAuthorized && normalizeUser(event.Sender) != normalizeUser(event.Author) {
 		if _, senderErr := gate.Policy.Authorize(event.Sender, changes); senderErr != nil {

--- a/internal/productownership/gate_test.go
+++ b/internal/productownership/gate_test.go
@@ -165,6 +165,10 @@ func TestGateAllowsTrustedProductOnboardingPolicy(t *testing.T) {
 		switch request.Method {
 		case http.MethodGet:
 			writer.Header().Set("Content-Type", "application/json")
+			if strings.HasSuffix(request.URL.Path, "/reviews") {
+				_, _ = writer.Write([]byte(`[{"id":1,"user":{"login":"CoreMaintainer"},"state":"APPROVED","commit_id":"0123456789abcdef0123456789abcdef01234567"}]`))
+				return
+			}
 			_, _ = writer.Write([]byte(`[{"filename":".github/product-owners.json","status":"modified"}]`))
 		case http.MethodPost:
 			var body map[string]string

--- a/scripts/recheck-product-ownership.sh
+++ b/scripts/recheck-product-ownership.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+mode="${1:-check}"
+if [[ "${mode}" != 'check' && "${mode}" != 'list' ]]; then
+  echo 'expected check or list mode' >&2
+  exit 2
+fi
+review_dir="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/product-ownership-review.XXXXXX")"
+trap 'rm -rf "${review_dir}"' EXIT
+
+if [[ "${mode}" == 'check' ]]; then
+  go build -o "${review_dir}/product-ownership" ./cmd/product-ownership
+fi
+
+# workflow_run may omit pull_requests for forks. Read live PRs from GitHub
+# instead of trusting artifacts, branch content, or a relayed event payload.
+if [[ -n "${PRODUCT_OWNERSHIP_PR:-}" ]]; then
+  [[ "${PRODUCT_OWNERSHIP_PR}" =~ ^[1-9][0-9]*$ ]] || exit 2
+  numbers="${PRODUCT_OWNERSHIP_PR}"
+else
+  numbers="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls?state=open&base=master&per_page=100" --jq '.[].number')"
+fi
+result=0
+while IFS= read -r number; do
+  [[ -n "${number}" ]] || continue
+  gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}" >"${review_dir}/pull-request.json"
+  if ! jq -e '.state == "open" and .base.ref == "master" and .changed_files == 1' "${review_dir}/pull-request.json" >/dev/null; then
+    continue
+  fi
+  author="$(jq -r '.user.login' "${review_dir}/pull-request.json")"
+  # Core-authored PRs keep the original event-sender check. A review must not
+  # turn an unauthorized push to a Core author's branch into an authorized one.
+  if jq -e --arg author "${author}" '.core.github_users | map(ascii_downcase) | index($author | ascii_downcase) != null' .github/product-owners.json >/dev/null; then
+    continue
+  fi
+  filename="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}/files" --jq '.[].filename')"
+  [[ "${filename}" == '.github/product-owners.json' ]] || continue
+  if [[ "${mode}" == 'list' ]]; then
+    printf '%s\n' "${number}"
+    continue
+  fi
+
+  # A review does not change the proposal. Revalidate its current author and
+  # contents; the API review records determine the approving Core identity.
+  jq --arg repository "${GITHUB_REPOSITORY}" \
+    '{repository: {full_name: $repository}, sender: .user, pull_request: .}' \
+    "${review_dir}/pull-request.json" >"${review_dir}/event.json"
+  if ! "${review_dir}/product-ownership" -config .github/product-owners.json -event "${review_dir}/event.json"; then
+    result=1
+  fi
+done <<<"${numbers}"
+exit "${result}"

--- a/scripts/recheck_product_ownership_test.go
+++ b/scripts/recheck_product_ownership_test.go
@@ -1,0 +1,117 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRecheckProductOwnership(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq is required by the GitHub runner script")
+	}
+	script, err := filepath.Abs("recheck-product-ownership.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name        string
+		apiFailure  bool
+		mode        string
+		number      string
+		wantFailure bool
+		wantCalls   string
+		wantOutput  string
+	}{
+		{name: "checks all proposals despite a rejected proposal", mode: "check", wantFailure: true, wantCalls: "1\n3"},
+		{name: "API failure is not a successful check", mode: "check", apiFailure: true, wantFailure: true},
+		{name: "lists only non-Core ownership proposals", mode: "list", wantOutput: "1\n3"},
+		{name: "checks one PR for the workflow matrix", mode: "check", number: "3", wantCalls: "3"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.Mkdir(filepath.Join(dir, ".github"), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, ".github", "product-owners.json"), []byte(`{"core":{"github_users":["CoreOwner"]}}`), 0644); err != nil {
+				t.Fatal(err)
+			}
+			writeExecutable := func(name, contents string) string {
+				t.Helper()
+				filename := filepath.Join(dir, name)
+				if err := os.WriteFile(filename, []byte(contents), 0755); err != nil {
+					t.Fatal(err)
+				}
+				return filename
+			}
+			checker := writeExecutable("checker", `#!/usr/bin/env bash
+set -euo pipefail
+[[ "$1" == '-config' && "$3" == '-event' ]]
+jq -e '.repository.full_name == "ucloud/test" and .sender.login == .pull_request.user.login' "$4" >/dev/null
+number="$(jq -r '.pull_request.number' "$4")"
+printf '%s\n' "$number" >>"${REVIEW_CALLS}"
+[[ "$number" == '3' ]]
+`)
+			writeExecutable("go", `#!/usr/bin/env bash
+set -euo pipefail
+[[ "$1" == 'build' && "$2" == '-o' && "$4" == './cmd/product-ownership' ]]
+cp "${REVIEW_CHECKER}" "$3"
+`)
+			writeExecutable("gh", `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${REVIEW_API_FAILURE}" == 'true' ]]; then exit 1; fi
+case "$*" in
+  'api --paginate repos/ucloud/test/pulls?state=open&base=master&per_page=100 --jq .[].number')
+    printf '1\n2\n3\n4\n5\n' ;;
+  'api repos/ucloud/test/pulls/'[12345])
+    number="${2##*/}"
+    changed=1
+    if [[ "$number" == '4' ]]; then changed=2; fi
+    author=NewOwner
+    if [[ "$number" == '5' ]]; then author=COREOWNER; fi
+    jq -n --argjson number "$number" --argjson changed "$changed" --arg author "$author" \
+      '{number:$number,state:"open",base:{ref:"master"},changed_files:$changed,user:{login:$author}}' ;;
+  'api repos/ucloud/test/pulls/'[13]'/files --jq .[].filename')
+    printf '.github/product-owners.json\n' ;;
+  'api repos/ucloud/test/pulls/2/files --jq .[].filename')
+    printf 'products/ulb/product.go\n' ;;
+  *) printf 'unexpected request: %s\n' "$*" >&2; exit 2 ;;
+esac
+`)
+			calls := filepath.Join(dir, "calls")
+			command := exec.Command("bash", script, test.mode)
+			command.Dir = dir
+			failure := "false"
+			if test.apiFailure {
+				failure = "true"
+			}
+			command.Env = append(os.Environ(),
+				"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+				"GITHUB_REPOSITORY=ucloud/test", "RUNNER_TEMP="+dir,
+				"PRODUCT_OWNERSHIP_PR="+test.number,
+				"REVIEW_CHECKER="+checker, "REVIEW_CALLS="+calls, "REVIEW_API_FAILURE="+failure,
+			)
+			output, err := command.CombinedOutput()
+			if (err != nil) != test.wantFailure {
+				t.Fatalf("recheck error = %v, wantFailure = %t; output: %s", err, test.wantFailure, output)
+			}
+			got, readErr := os.ReadFile(calls)
+			if test.wantCalls == "" {
+				if !os.IsNotExist(readErr) {
+					t.Fatalf("checker should not have been invoked: %s, %v", got, readErr)
+				}
+			} else if readErr != nil || strings.TrimSpace(string(got)) != test.wantCalls {
+				t.Fatalf("checked PRs = %q, error = %v; want %q; output: %s", got, readErr, test.wantCalls, output)
+			}
+			if test.wantOutput != "" && strings.TrimSpace(string(output)) != test.wantOutput {
+				t.Fatalf("output = %q, want %q", output, test.wantOutput)
+			}
+			leftovers, err := filepath.Glob(filepath.Join(dir, "product-ownership-review.*"))
+			if err != nil || len(leftovers) != 0 {
+				t.Fatalf("review temp directory was not cleaned: %v, %v", leftovers, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
非 Core 用户提交 `.github/product-owners.json` 时，原有校验只验证名单结构及变更范围，缺少 Core 审批要求。本次修复要求可信基础配置中的 Core 维护者批准 PR 当前提交；非 Core、旧提交、已撤销或被后续拒绝覆盖的审批均不能通过。

审批提交、编辑或撤销后，工作流从 GitHub API 读取当前名单提案，按 PR 重新校验并更新状态。校验代码和 Core 名单来自可信基础分支，API 异常时拒绝放行；保留 Core 作者原有的推送者权限校验。

验证：

- `GOTOOLCHAIN=go1.19.5 make compat test vet` 通过（未启用 `TF_ACC`）。
- `go test -race ./internal/productownership ./cmd/product-ownership ./scripts -count=1` 通过。
- 最终变更再次通过上述三个包的普通测试，以及工作流 actionlint、Shell 语法和 diff 格式检查。
- 回归测试覆盖审批身份、当前提交、撤销、后续拒绝、分页、API 错误及按 PR 重跑。

此 PR 目标为 `feat/product-package-compatibility`，不包含设计或方案文档。现有工作流仅匹配 `master`，本 PR 不会触发对应的 PR 校验。工作流进入 `master` 后，还需将 `product-ownership` 配置为必需检查；本次未修改分支保护，也未执行云端验收测试。
