### PR TITLE
fix: 修复产品验收测试参数与默认清理范围

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,6 +15,8 @@ default: build
 build: fmtcheck
 	go install
 
+# UDPN is currently the only package registering resource sweepers.
+sweep: TEST=./products/udpn
 sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
 	go test $(TEST) -v -sweep=$(SWEEP) $(SWEEPARGS)
@@ -37,7 +39,7 @@ testacc: fmtcheck
 			echo "ERROR: Product $$product has no acceptance tests" >&2; \
 			exit 3; \
 		fi; \
-		TF_ACC=1 go test -cover "./products/$$product" -v -timeout 120m -parallel=32
+		TF_ACC=1 go test -cover "./products/$$product" -v $(TESTARGS) -timeout 120m -parallel=32
 
 vet:
 	@echo "go vet ."

--- a/scripts/make_targets_test.go
+++ b/scripts/make_targets_test.go
@@ -1,0 +1,87 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMakeTestTargets(t *testing.T) {
+	makefile, err := os.ReadFile("../GNUmakefile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "acceptance forwards test selection and options",
+			args: []string{"testacc", "PRODUCT=uhost", "TESTARGS=-run '^TestAccSelected$$' -count=1"},
+			want: "TF_ACC= test ./products/uhost -list ^TestAcc\nTF_ACC=1 test -cover ./products/uhost -v -run ^TestAccSelected$ -count=1 -timeout 120m -parallel=32\n",
+		},
+		{
+			name: "sweep defaults to the package with registered sweepers",
+			args: []string{"sweep"},
+			want: "TF_ACC= test ./products/udpn -v -sweep=cn-bj2,cn-sh2\n",
+		},
+		{
+			name: "sweep preserves explicit package region and filter",
+			args: []string{"sweep", "TEST=./products/ulb", "SWEEP=cn-bj2", "SWEEPARGS=-sweep-run=selected"},
+			want: "TF_ACC= test ./products/ulb -v -sweep=cn-bj2 -sweep-run=selected\n",
+		},
+		{
+			name: "unit tests retain all packages",
+			args: []string{"test"},
+			want: "TF_ACC= test ./... -timeout=30s -parallel=32\n",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(dir, "products", "uhost"), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "GNUmakefile"), makefile, 0644); err != nil {
+				t.Fatal(err)
+			}
+			// Execute the real Make recipes without permitting any Go or cloud work.
+			fakeGo := `#!/bin/sh
+printf 'TF_ACC=%s %s\n' "${TF_ACC:-}" "$*" >>"${MAKE_TEST_CALLS}"
+case " $* " in
+  *' -list '*) printf 'TestAccSelected\n' ;;
+esac
+`
+			if err := os.WriteFile(filepath.Join(dir, "go"), []byte(fakeGo), 0755); err != nil {
+				t.Fatal(err)
+			}
+			calls := filepath.Join(dir, "calls")
+			command := exec.Command("make", append([]string{"--no-print-directory", "-o", "fmtcheck"}, test.args...)...)
+			command.Dir = dir
+			for _, variable := range os.Environ() {
+				key := strings.SplitN(variable, "=", 2)[0]
+				switch key {
+				case "TF_ACC", "MAKEFLAGS", "MFLAGS", "MAKEOVERRIDES", "TEST", "TESTARGS", "PRODUCT", "SWEEP", "SWEEPARGS":
+					continue
+				}
+				command.Env = append(command.Env, variable)
+			}
+			command.Env = append(command.Env,
+				"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+				"MAKE_TEST_CALLS="+calls,
+			)
+			if output, err := command.CombinedOutput(); err != nil {
+				t.Fatalf("make failed: %v\n%s", err, output)
+			}
+			got, err := os.ReadFile(calls)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != test.want {
+				t.Fatalf("go invocations = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
修复产品拆包后的两个测试入口问题：`make testacc` 恢复传递 `TESTARGS`，指定 `-run` 时只运行选中的用例；`make sweep` 默认只运行当前注册了 sweeper 的 `./products/udpn`，避免向内部包传递不支持的 `-sweep` 参数。

保留命令行 `TEST`、`SWEEP`、`SWEEPARGS` 覆盖；普通 `make test` 默认仍为 `./...`。新增回归测试执行真实 Make 配方并替换 Go 命令，覆盖用例筛选、默认清理范围和参数覆盖，不访问云 API。

验证：

- 修改前，回归测试分别复现筛选参数丢失和清理范围为 `./...`；修改后通过。
- `env -u TF_ACC GOTOOLCHAIN=go1.19.5 make compat test vet` 通过。
- `make sweep SWEEP= SWEEPARGS=-run=TestNoCloudCommandSmoke` 通过：清空区域并选择不存在的测试，仅检查真实入口的参数解析，无云资源操作。
- `git diff --check` 通过。

目标分支为 `feat/product-package-compatibility`。本次只修改 Makefile 和回归测试，不调整分支保护；未执行真实云端验收或清理。
