### PR TITLE
fix: 更新 umem 产品维护者名单

### DIFF
--- a/.github/product-owners.json
+++ b/.github/product-owners.json
@@ -146,7 +146,7 @@
     },
     "umem": {
       "github_users": [
-        "Ali1213"
+        "sunpuxi"
       ],
       "paths": [
         "products/umem/**",


### PR DESCRIPTION
将 umem 的 GitHub 维护者从 Ali1213 更新为 sunpuxi。验证：go test ./internal/productownership ./internal/productownershipsync ./cmd/product-ownership ./cmd/product-ownership-sync -count=1