### PR TITLE
feat: automate label-driven provider releases

### DIFF
--- a/.github/workflows/release-intent.yml
+++ b/.github/workflows/release-intent.yml
@@ -1,0 +1,32 @@
+name: Release intent
+
+on:
+  pull_request_target:
+    branches:
+      - master
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  release-intent:
+    name: Enforce release intent
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out trusted default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Require one release label
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash scripts/release-policy.sh check-pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,47 +1,93 @@
-# This GitHub action can publish assets for release when a tag is created.
-# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
-#
-# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your 
-# private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
-# secret. If you would rather own your own GPG handling, please fork this action
-# or use an alternative one for key handling.
-#
-# You will need to pass the `--batch` flag to `gpg` in your signing step 
-# in `goreleaser` to indicate this is being used in a non-interactive mode.
-#
 name: release
+
 on:
+  workflow_run:
+    workflows: [test]
+    types: [completed]
+    branches: [master]
   push:
     tags:
-      - 'v*'
+      - "v*"
+
+permissions: {}
+
+concurrency:
+  group: provider-release
+  cancel-in-progress: false
+
 jobs:
   goreleaser:
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v6
-      -
-        name: Unshallow
-        run: git fetch --prune --unshallow
-      -
-        name: Set up Go
-        uses: actions/setup-go@v6
+      - name: Check out tested revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          go-version-file: 'go.mod'
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
+      - name: Fetch release history
+        run: git fetch --force --tags origin '+refs/heads/master:refs/remotes/origin/master'
+      - id: plan
+        name: Resolve release intent and version
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == 'workflow_run' ]]; then
+            bash scripts/release-policy.sh plan-auto
+          else
+            bash scripts/release-policy.sh plan-tag
+          fi
+      - name: Check out release revision
+        if: steps.plan.outputs.release == 'true'
+        env:
+          RELEASE_SHA: ${{ steps.plan.outputs.release_sha }}
+        run: git checkout --detach "${RELEASE_SHA}"
+      - name: Set up Go
+        if: steps.plan.outputs.release == 'true'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
           cache: true
-
+      - name: Validate GoReleaser configuration
+        if: steps.plan.outputs.release == 'true'
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
+        with:
+          version: v2.18.1
+          args: check
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6.3.0
+        if: steps.plan.outputs.release == 'true'
         id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
-      -
-        name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+      - name: Create release tag
+        if: steps.plan.outputs.release == 'true' && steps.plan.outputs.existing_tag != 'true'
+        env:
+          RELEASE_TAG: ${{ steps.plan.outputs.tag }}
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_TAG}"
+          git push origin "refs/tags/${RELEASE_TAG}"
+      - name: Run GoReleaser
+        if: steps.plan.outputs.release == 'true'
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
+          version: v2.18.1
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GORELEASER_CURRENT_TAG: ${{ steps.plan.outputs.tag }}
+          GORELEASER_PREVIOUS_TAG: ${{ steps.plan.outputs.previous_tag }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ builds:
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
+- formats: [zip]
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:
@@ -48,6 +48,10 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
+  use_existing_draft: true
+  replace_existing_artifacts: true
+  preflight:
+    fail_on_error: true
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'

--- a/internal/productownership/repository_policy_test.go
+++ b/internal/productownership/repository_policy_test.go
@@ -117,6 +117,100 @@ func TestProductOwnershipWorkflowNeverExecutesPullRequestCode(t *testing.T) {
 	}
 }
 
+func TestReleaseIntentWorkflowUsesTrustedPullRequestMetadata(t *testing.T) {
+	workflow, err := os.ReadFile("../../.github/workflows/release-intent.yml")
+	if err != nil {
+		t.Fatalf("read release intent workflow: %v", err)
+	}
+	content := string(workflow)
+	for _, required := range []string{
+		"pull_request_target:",
+		"- labeled",
+		"- unlabeled",
+		"statuses: write",
+		"bash scripts/release-policy.sh check-pr",
+	} {
+		if !strings.Contains(content, required) {
+			t.Fatalf("release intent workflow must contain %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"github.event.pull_request.head",
+		"uses: actions/checkout@v",
+		"gh pr checkout",
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Fatalf("release intent workflow contains unsafe pull request token %q", forbidden)
+		}
+	}
+}
+
+func TestReleaseWorkflowRunsOnlyAfterSuccessfulMasterCI(t *testing.T) {
+	workflow, err := os.ReadFile("../../.github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+	content := string(workflow)
+	for _, required := range []string{
+		"workflow_run:",
+		"workflows: [test]",
+		"types: [completed]",
+		"branches: [master]",
+		"github.event.workflow_run.event == 'push'",
+		"github.event.workflow_run.conclusion == 'success'",
+		"pull-requests: read",
+		"contents: write",
+		"cancel-in-progress: false",
+		"bash scripts/release-policy.sh plan-auto",
+		"bash scripts/release-policy.sh plan-tag",
+		"git checkout --detach \"${RELEASE_SHA}\"",
+		"git push origin \"refs/tags/${RELEASE_TAG}\"",
+		"version: v2.18.1",
+		"args: release --clean",
+		"GORELEASER_CURRENT_TAG: ${{ steps.plan.outputs.tag }}",
+		"GORELEASER_PREVIOUS_TAG: ${{ steps.plan.outputs.previous_tag }}",
+	} {
+		if !strings.Contains(content, required) {
+			t.Fatalf("release workflow must contain %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"workflow_dispatch:",
+		"uses: actions/checkout@v",
+		"uses: actions/setup-go@v",
+		"uses: crazy-max/ghaction-import-gpg@v",
+		"uses: goreleaser/goreleaser-action@v",
+		"version: \"~> v2\"",
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Fatalf("release workflow contains disallowed token %q", forbidden)
+		}
+	}
+}
+
+func TestGoReleaserConfigurationUsesCurrentArchiveFormat(t *testing.T) {
+	configuration, err := os.ReadFile("../../.goreleaser.yml")
+	if err != nil {
+		t.Fatalf("read GoReleaser configuration: %v", err)
+	}
+	content := string(configuration)
+	if !strings.Contains(content, "- formats: [zip]") {
+		t.Fatal("GoReleaser archives must use the current formats property")
+	}
+	if strings.Contains(content, "- format: zip") {
+		t.Fatal("GoReleaser archives must not use the deprecated format property")
+	}
+	for _, required := range []string{
+		"use_existing_draft: true",
+		"replace_existing_artifacts: true",
+		"fail_on_error: true",
+	} {
+		if !strings.Contains(content, required) {
+			t.Fatalf("GoReleaser retry configuration must contain %q", required)
+		}
+	}
+}
+
 func TestProductAcceptanceWorkflowUsesProductEnvironmentOnMaster(t *testing.T) {
 	workflow, err := os.ReadFile("../../.github/workflows/product-acceptance.yml")
 	if err != nil {

--- a/scripts/release-policy.sh
+++ b/scripts/release-policy.sh
@@ -1,0 +1,472 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly RELEASE_LABEL_PREFIX='release:'
+readonly RELEASE_STATUS_CONTEXT='release-intent'
+readonly STABLE_TAG_PATTERN='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+
+RELEASE_COMMITS_FILE=''
+RELEASE_PULL_REQUESTS_FILE=''
+
+cleanup() {
+  if [[ -n "${RELEASE_COMMITS_FILE}" ]]; then
+    rm -f -- "${RELEASE_COMMITS_FILE}"
+  fi
+  if [[ -n "${RELEASE_PULL_REQUESTS_FILE}" ]]; then
+    rm -f -- "${RELEASE_PULL_REQUESTS_FILE}"
+  fi
+}
+
+trap cleanup EXIT
+
+die() {
+  printf 'release policy: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command $1 is unavailable"
+}
+
+require_repository() {
+  local repository="$1"
+  [[ "${repository}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] ||
+    die "GitHub repository ${repository} must be owner/name"
+}
+
+require_commit_sha() {
+  local sha="$1"
+  [[ "${sha}" =~ ^[0-9a-fA-F]{40}$ ]] || die "commit SHA ${sha} is invalid"
+}
+
+emit_output() {
+  local name="$1"
+  local value="$2"
+  [[ -n "${GITHUB_OUTPUT:-}" ]] || die 'GITHUB_OUTPUT is empty'
+  printf '%s=%s\n' "${name}" "${value}" >>"${GITHUB_OUTPUT}"
+}
+
+set_release_status() {
+  local repository="$1"
+  local sha="$2"
+  local state="$3"
+  local description="$4"
+  local target_url="${GITHUB_SERVER_URL:-https://github.com}/${repository}/actions/runs/${GITHUB_RUN_ID:-0}"
+
+  gh api --method POST "repos/${repository}/statuses/${sha}" \
+    -f "state=${state}" \
+    -f "context=${RELEASE_STATUS_CONTEXT}" \
+    -f "description=${description}" \
+    -f "target_url=${target_url}" >/dev/null
+}
+
+set_pull_request_statuses() {
+  local repository="$1"
+  local head_sha="$2"
+  local merge_sha="$3"
+  local state="$4"
+  local description="$5"
+
+  set_release_status "${repository}" "${head_sha}" "${state}" "${description}"
+  if [[ -n "${merge_sha}" && "${merge_sha}" != "${head_sha}" ]]; then
+    set_release_status "${repository}" "${merge_sha}" "${state}" "${description}"
+  fi
+}
+
+fail_pull_request_check() {
+  local repository="$1"
+  local head_sha="$2"
+  local merge_sha="$3"
+  local message="$4"
+
+  if ! set_pull_request_statuses "${repository}" "${head_sha}" "${merge_sha}" failure 'select exactly one supported release label'; then
+    printf 'release policy: failed to publish release-intent failure status\n' >&2
+  fi
+  die "${message}"
+}
+
+check_pull_request() {
+  require_command gh
+  require_command jq
+  [[ -n "${GITHUB_EVENT_PATH:-}" ]] || die 'GITHUB_EVENT_PATH is empty'
+
+  local repository
+  local head_sha
+  local merge_sha
+  repository="$(jq -er '.repository.full_name | strings | select(length > 0)' "${GITHUB_EVENT_PATH}")" ||
+    die 'pull request event has no repository.full_name'
+  head_sha="$(jq -er '.pull_request.head.sha | strings | select(length > 0)' "${GITHUB_EVENT_PATH}")" ||
+    die 'pull request event has no head SHA'
+  merge_sha="$(jq -r '.pull_request.merge_commit_sha // ""' "${GITHUB_EVENT_PATH}")"
+  require_repository "${repository}"
+  require_commit_sha "${head_sha}"
+  if [[ -n "${merge_sha}" ]]; then
+    require_commit_sha "${merge_sha}"
+  fi
+
+  set_pull_request_statuses "${repository}" "${head_sha}" "${merge_sha}" pending 'checking pull request release intent'
+
+  local release_labels
+  local label_count
+  local release_label
+  release_labels="$(jq -c '[.pull_request.labels[]?.name | strings | select(startswith("release:"))]' "${GITHUB_EVENT_PATH}")" ||
+    fail_pull_request_check "${repository}" "${head_sha}" "${merge_sha}" 'cannot read pull request labels'
+  label_count="$(jq -r 'length' <<<"${release_labels}")"
+  if [[ "${label_count}" != '1' ]]; then
+    fail_pull_request_check "${repository}" "${head_sha}" "${merge_sha}" \
+      "pull request must have exactly one release label; found ${label_count}"
+  fi
+
+  release_label="$(jq -r '.[0]' <<<"${release_labels}")"
+  case "${release_label}" in
+    release:major | release:minor | release:patch | release:none) ;;
+    *)
+      fail_pull_request_check "${repository}" "${head_sha}" "${merge_sha}" \
+        "unsupported release label ${release_label}"
+      ;;
+  esac
+
+  set_pull_request_statuses "${repository}" "${head_sha}" "${merge_sha}" success \
+    "release intent is ${release_label#"${RELEASE_LABEL_PREFIX}"}"
+  printf 'release policy: %s\n' "${release_label}"
+}
+
+stable_tags_merged_into() {
+  local ref="$1"
+  local tag
+  while IFS= read -r tag; do
+    if [[ "${tag}" =~ ${STABLE_TAG_PATTERN} ]]; then
+      printf '%s\n' "${tag}"
+    fi
+  done < <(git tag --merged "${ref}" --sort=-version:refname)
+}
+
+latest_stable_tag() {
+  local ref="$1"
+  local tag
+  while IFS= read -r tag; do
+    printf '%s\n' "${tag}"
+    return 0
+  done < <(stable_tags_merged_into "${ref}")
+  return 1
+}
+
+latest_published_tag() {
+  local repository="$1"
+  local ref="$2"
+  local tag
+  while IFS= read -r tag; do
+    release_exists "${repository}" "${tag}"
+    if [[ "${RELEASE_PUBLISHED}" == 'true' ]]; then
+      printf '%s\n' "${tag}"
+      return 0
+    fi
+  done < <(stable_tags_merged_into "${ref}")
+  return 1
+}
+
+unpublished_tags_after() {
+  local ref="$1"
+  local published_tag="$2"
+  local tag
+  while IFS= read -r tag; do
+    if [[ "${tag}" == "${published_tag}" ]]; then
+      return 0
+    fi
+    printf '%s\n' "${tag}"
+  done < <(stable_tags_merged_into "${ref}")
+  die "published tag ${published_tag} is not merged into ${ref}"
+}
+
+release_exists() {
+  local repository="$1"
+  local tag="$2"
+  local response
+
+  if response="$(gh api "repos/${repository}/releases/tags/${tag}" 2>&1)"; then
+    RELEASE_DRAFT="$(jq -r 'if (.draft | type) == "boolean" then .draft else error("draft must be boolean") end' <<<"${response}")" ||
+      die "GitHub Release ${tag} has no valid draft state"
+    if [[ "${RELEASE_DRAFT}" == 'false' ]]; then
+      RELEASE_PUBLISHED='true'
+    else
+      RELEASE_PUBLISHED='false'
+    fi
+  elif [[ "${response}" == *'HTTP 404'* ]]; then
+    RELEASE_DRAFT='false'
+    RELEASE_PUBLISHED='false'
+  else
+    die "cannot determine whether GitHub Release ${tag} exists: ${response}"
+  fi
+}
+
+pull_request_number_for_commit() {
+  local repository="$1"
+  local commit="$2"
+  local associations
+  local pull_requests
+  local association_count
+
+  associations="$(gh api "repos/${repository}/commits/${commit}/pulls")" ||
+    die "cannot read pull request associations for commit ${commit}"
+  pull_requests="$(jq -c '[.[] | select(.merged_at != null and .base.ref == "master") | .number] | unique' <<<"${associations}")" ||
+    die "cannot parse pull request associations for commit ${commit}"
+  association_count="$(jq -r 'length' <<<"${pull_requests}")"
+  if [[ "${association_count}" != '1' ]]; then
+    die "commit ${commit} must identify exactly one pull request merged into master; found ${association_count}"
+  fi
+  jq -r '.[0]' <<<"${pull_requests}"
+}
+
+release_level_for_pull_request() {
+  local repository="$1"
+  local pull_request="$2"
+  local metadata
+  local label_count
+  local release_label
+
+  metadata="$(gh api "repos/${repository}/pulls/${pull_request}")" ||
+    die "cannot read pull request #${pull_request}"
+  if [[ "$(jq -r '.merged_at // ""' <<<"${metadata}")" == '' ||
+    "$(jq -r '.base.ref // ""' <<<"${metadata}")" != 'master' ]]; then
+    die "pull request #${pull_request} is not merged into master"
+  fi
+
+  label_count="$(jq '[.labels[]?.name | strings | select(startswith("release:"))] | length' <<<"${metadata}")" ||
+    die "cannot read labels for pull request #${pull_request}"
+  if [[ "${label_count}" != '1' ]]; then
+    die "pull request #${pull_request} must have exactly one release label; found ${label_count}"
+  fi
+  release_label="$(jq -r '[.labels[]?.name | strings | select(startswith("release:"))][0]' <<<"${metadata}")"
+  case "${release_label}" in
+    release:major) printf 'major\n' ;;
+    release:minor) printf 'minor\n' ;;
+    release:patch) printf 'patch\n' ;;
+    release:none) printf 'none\n' ;;
+    *) die "pull request #${pull_request} has unsupported release label ${release_label}" ;;
+  esac
+}
+
+next_tag() {
+  local previous_tag="$1"
+  local level="$2"
+  [[ "${previous_tag}" =~ ${STABLE_TAG_PATTERN} ]] || die "tag ${previous_tag} is not stable SemVer"
+  local major="${BASH_REMATCH[1]}"
+  local minor="${BASH_REMATCH[2]}"
+  local patch="${BASH_REMATCH[3]}"
+
+  case "${level}" in
+    major)
+      major=$((major + 1))
+      minor=0
+      patch=0
+      ;;
+    minor)
+      minor=$((minor + 1))
+      patch=0
+      ;;
+    patch) patch=$((patch + 1)) ;;
+    *) die "cannot calculate a tag for release level ${level}" ;;
+  esac
+  printf 'v%s.%s.%s\n' "${major}" "${minor}" "${patch}"
+}
+
+evaluate_release_range() {
+  local repository="$1"
+  local previous_tag="$2"
+  local target_sha="$3"
+  local commit
+  local pull_request
+  local level
+  local level_rank
+  local highest_level='none'
+  local highest_rank=0
+
+  RELEASE_COMMITS_FILE="$(mktemp)"
+  RELEASE_PULL_REQUESTS_FILE="$(mktemp)"
+  git rev-list --first-parent --reverse "${previous_tag}..${target_sha}" >"${RELEASE_COMMITS_FILE}"
+  [[ -s "${RELEASE_COMMITS_FILE}" ]] || die "tag ${previous_tag} already points at release target ${target_sha}"
+
+  while IFS= read -r commit; do
+    pull_request="$(pull_request_number_for_commit "${repository}" "${commit}")"
+    printf '%s\n' "${pull_request}" >>"${RELEASE_PULL_REQUESTS_FILE}"
+  done <"${RELEASE_COMMITS_FILE}"
+  sort -nu -o "${RELEASE_PULL_REQUESTS_FILE}" "${RELEASE_PULL_REQUESTS_FILE}"
+
+  RELEASE_PULL_REQUESTS=''
+  while IFS= read -r pull_request; do
+    level="$(release_level_for_pull_request "${repository}" "${pull_request}")"
+    case "${level}" in
+      major) level_rank=3 ;;
+      minor) level_rank=2 ;;
+      patch) level_rank=1 ;;
+      none) level_rank=0 ;;
+      *) die "pull request #${pull_request} returned invalid release level ${level}" ;;
+    esac
+    if ((level_rank > highest_rank)); then
+      highest_rank="${level_rank}"
+      highest_level="${level}"
+    fi
+    if [[ -z "${RELEASE_PULL_REQUESTS}" ]]; then
+      RELEASE_PULL_REQUESTS="${pull_request}"
+    else
+      RELEASE_PULL_REQUESTS="${RELEASE_PULL_REQUESTS},${pull_request}"
+    fi
+  done <"${RELEASE_PULL_REQUESTS_FILE}"
+
+  RELEASE_LEVEL="${highest_level}"
+  if [[ "${highest_level}" == 'none' ]]; then
+    RELEASE_EXPECTED_TAG=''
+  else
+    RELEASE_EXPECTED_TAG="$(next_tag "${previous_tag}" "${highest_level}")"
+  fi
+}
+
+validate_plan_environment() {
+  require_command gh
+  require_command git
+  require_command jq
+  [[ -n "${GITHUB_REPOSITORY:-}" ]] || die 'GITHUB_REPOSITORY is empty'
+  require_repository "${GITHUB_REPOSITORY}"
+  git rev-parse --verify 'refs/remotes/origin/master^{commit}' >/dev/null 2>&1 ||
+    die 'refs/remotes/origin/master is unavailable'
+}
+
+validate_release_target() {
+  local target_sha="$1"
+  require_commit_sha "${target_sha}"
+  git cat-file -e "${target_sha}^{commit}" 2>/dev/null || die "release target ${target_sha} is unavailable"
+  git merge-base --is-ancestor "${target_sha}" refs/remotes/origin/master ||
+    die "release target ${target_sha} is not on master"
+}
+
+emit_skip() {
+  emit_output release false
+  emit_output reason "$1"
+}
+
+plan_existing_tag() {
+  local repository="$1"
+  local tag="$2"
+  local target_sha="$3"
+  local previous_tag="$4"
+
+  release_exists "${repository}" "${tag}"
+  if [[ "${RELEASE_PUBLISHED}" == 'true' ]]; then
+    emit_skip already-released
+    return 0
+  fi
+
+  [[ "${previous_tag}" =~ ${STABLE_TAG_PATTERN} ]] || die "previous tag ${previous_tag} is not stable SemVer"
+  local previous_tag_sha
+  previous_tag_sha="$(git rev-list -n 1 "${previous_tag}")"
+  git merge-base --is-ancestor "${previous_tag_sha}" "${target_sha}" ||
+    die "tag ${tag} is not descended from published tag ${previous_tag}"
+  evaluate_release_range "${repository}" "${previous_tag}" "${target_sha}"
+  if [[ "${RELEASE_LEVEL}" == 'none' ]]; then
+    die "tag ${tag} exists for changes that are all marked release:none"
+  fi
+  if [[ "${RELEASE_EXPECTED_TAG}" != "${tag}" ]]; then
+    die "tag ${tag} does not match expected tag ${RELEASE_EXPECTED_TAG}"
+  fi
+
+  emit_output release true
+  emit_output tag "${tag}"
+  emit_output previous_tag "${previous_tag}"
+  emit_output level resume
+  emit_output pull_requests "${RELEASE_PULL_REQUESTS}"
+  emit_output existing_tag true
+  emit_output release_sha "${target_sha}"
+}
+
+plan_automatic_release() {
+  validate_plan_environment
+  [[ -n "${RELEASE_TARGET_SHA:-}" ]] || die 'RELEASE_TARGET_SHA is empty'
+  validate_release_target "${RELEASE_TARGET_SHA}"
+
+  local latest_tag
+  local published_tag
+  local published_tag_sha
+  local unpublished_tags
+  local unpublished_count
+  local pending_tag
+  local pending_tag_sha
+  latest_tag="$(latest_stable_tag refs/remotes/origin/master)" ||
+    die 'no stable SemVer tag is merged into master'
+  published_tag="$(latest_published_tag "${GITHUB_REPOSITORY}" refs/remotes/origin/master)" ||
+    die 'no published stable SemVer tag is merged into master'
+  published_tag_sha="$(git rev-list -n 1 "${published_tag}")"
+
+  unpublished_tags="$(unpublished_tags_after refs/remotes/origin/master "${published_tag}" | jq -Rsc 'split("\n") | map(select(length > 0))')"
+  unpublished_count="$(jq -r 'length' <<<"${unpublished_tags}")"
+  if ((unpublished_count > 1)); then
+    die "multiple unpublished stable tags exist after ${published_tag}: $(jq -r 'join(",")' <<<"${unpublished_tags}")"
+  fi
+  if [[ "${unpublished_count}" == '1' ]]; then
+    pending_tag="$(jq -r '.[0]' <<<"${unpublished_tags}")"
+    pending_tag_sha="$(git rev-list -n 1 "${pending_tag}")"
+    plan_existing_tag "${GITHUB_REPOSITORY}" "${pending_tag}" "${pending_tag_sha}" "${published_tag}"
+    return 0
+  fi
+
+  [[ "${latest_tag}" == "${published_tag}" ]] || die "release tag state changed while planning"
+  if git merge-base --is-ancestor "${RELEASE_TARGET_SHA}" "${published_tag_sha}"; then
+    if [[ "${RELEASE_TARGET_SHA}" == "${published_tag_sha}" ]]; then
+      emit_skip already-released
+    else
+      emit_skip "covered-by-${published_tag}"
+    fi
+    return 0
+  fi
+  git merge-base --is-ancestor "${published_tag_sha}" "${RELEASE_TARGET_SHA}" ||
+    die "release target ${RELEASE_TARGET_SHA} and ${published_tag} have diverged"
+
+  evaluate_release_range "${GITHUB_REPOSITORY}" "${published_tag}" "${RELEASE_TARGET_SHA}"
+  if [[ "${RELEASE_LEVEL}" == 'none' ]]; then
+    emit_skip no-release-intent
+    return 0
+  fi
+
+  emit_output release true
+  emit_output tag "${RELEASE_EXPECTED_TAG}"
+  emit_output previous_tag "${published_tag}"
+  emit_output level "${RELEASE_LEVEL}"
+  emit_output pull_requests "${RELEASE_PULL_REQUESTS}"
+  emit_output existing_tag false
+  emit_output release_sha "${RELEASE_TARGET_SHA}"
+}
+
+plan_tag_release() {
+  validate_plan_environment
+  [[ -n "${RELEASE_TAG:-}" ]] || die 'RELEASE_TAG is empty'
+  [[ "${RELEASE_TAG}" =~ ${STABLE_TAG_PATTERN} ]] || die "tag ${RELEASE_TAG} is not stable SemVer"
+  git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}" >/dev/null 2>&1 ||
+    die "tag ${RELEASE_TAG} is unavailable"
+  local target_sha
+  target_sha="$(git rev-list -n 1 "refs/tags/${RELEASE_TAG}")"
+  validate_release_target "${target_sha}"
+
+  release_exists "${GITHUB_REPOSITORY}" "${RELEASE_TAG}"
+  if [[ "${RELEASE_PUBLISHED}" == 'true' ]]; then
+    emit_skip already-released
+    return 0
+  fi
+  local published_tag
+  local unpublished_tags
+  local unpublished_count
+  published_tag="$(latest_published_tag "${GITHUB_REPOSITORY}" refs/remotes/origin/master)" ||
+    die 'no published stable SemVer tag is merged into master'
+  unpublished_tags="$(unpublished_tags_after refs/remotes/origin/master "${published_tag}" | jq -Rsc 'split("\n") | map(select(length > 0))')"
+  unpublished_count="$(jq -r 'length' <<<"${unpublished_tags}")"
+  if [[ "${unpublished_count}" != '1' || "$(jq -r '.[0] // ""' <<<"${unpublished_tags}")" != "${RELEASE_TAG}" ]]; then
+    die "tag ${RELEASE_TAG} must be the only unpublished stable tag after ${published_tag}"
+  fi
+  plan_existing_tag "${GITHUB_REPOSITORY}" "${RELEASE_TAG}" "${target_sha}" "${published_tag}"
+}
+
+case "${1:-}" in
+  check-pr) check_pull_request ;;
+  plan-auto) plan_automatic_release ;;
+  plan-tag) plan_tag_release ;;
+  *) die 'usage: release-policy.sh {check-pr|plan-auto|plan-tag}' ;;
+esac

--- a/scripts/release_policy_test.go
+++ b/scripts/release_policy_test.go
@@ -1,0 +1,456 @@
+package scripts_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	releaseHeadSHA  = "0123456789abcdef0123456789abcdef01234567"
+	releaseMergeSHA = "89abcdef0123456789abcdef0123456789abcdef"
+)
+
+func TestReleasePolicyChecksPullRequestLabels(t *testing.T) {
+	script := releasePolicyScript(t)
+	for _, test := range []struct {
+		name        string
+		labels      []string
+		wantFailure bool
+		wantMessage string
+		wantState   string
+	}{
+		{name: "one supported label", labels: []string{"release:minor", "uhost"}, wantState: "success"},
+		{name: "missing release label", labels: []string{"uhost"}, wantFailure: true, wantMessage: "exactly one release label", wantState: "failure"},
+		{name: "multiple release labels", labels: []string{"release:minor", "release:patch"}, wantFailure: true, wantMessage: "exactly one release label", wantState: "failure"},
+		{name: "unsupported release label", labels: []string{"release:preview"}, wantFailure: true, wantMessage: "unsupported release label", wantState: "failure"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			eventPath := filepath.Join(dir, "event.json")
+			writeReleaseEvent(t, eventPath, test.labels)
+			calls := filepath.Join(dir, "gh-calls")
+			writeReleaseFakeGH(t, dir)
+
+			command := exec.Command("bash", script, "check-pr")
+			command.Env = append(os.Environ(),
+				"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+				"GITHUB_EVENT_PATH="+eventPath,
+				"GITHUB_SERVER_URL=https://github.example",
+				"GITHUB_RUN_ID=123",
+				"RELEASE_GH_CALLS="+calls,
+			)
+			output, err := command.CombinedOutput()
+			if (err != nil) != test.wantFailure {
+				t.Fatalf("check-pr error = %v, wantFailure = %t; output: %s", err, test.wantFailure, output)
+			}
+			if test.wantMessage != "" && !strings.Contains(string(output), test.wantMessage) {
+				t.Fatalf("check-pr output = %q, want %q", output, test.wantMessage)
+			}
+			contents, err := os.ReadFile(calls)
+			if err != nil {
+				t.Fatalf("read status calls: %v", err)
+			}
+			got := string(contents)
+			if count := strings.Count(got, "state=pending"); count != 2 {
+				t.Fatalf("pending status count = %d, want 2; calls: %s", count, got)
+			}
+			if count := strings.Count(got, "state="+test.wantState); count != 2 {
+				t.Fatalf("%s status count = %d, want 2; calls: %s", test.wantState, count, got)
+			}
+			if strings.Count(got, "context=release-intent") != 4 {
+				t.Fatalf("release-intent status count is wrong; calls: %s", got)
+			}
+		})
+	}
+}
+
+func TestReleasePolicyPlansHighestRequiredVersion(t *testing.T) {
+	repo := newReleaseRepository(t)
+	output, err := runReleasePolicyPlan(t, repo, repo.head, map[string]string{
+		"PR_10_LABEL": "release:minor",
+		"PR_11_LABEL": "release:patch",
+	})
+	if err != nil {
+		t.Fatalf("plan-auto error = %v", err)
+	}
+	want := map[string]string{
+		"release":       "true",
+		"tag":           "v1.40.0",
+		"previous_tag":  "v1.39.6",
+		"level":         "minor",
+		"pull_requests": "10,11",
+		"existing_tag":  "false",
+		"release_sha":   repo.head,
+	}
+	assertReleaseOutput(t, output, want)
+}
+
+func TestReleasePolicySkipsChangesMarkedNone(t *testing.T) {
+	repo := newReleaseRepository(t)
+	output, err := runReleasePolicyPlan(t, repo, repo.head, map[string]string{
+		"PR_10_LABEL": "release:none",
+		"PR_11_LABEL": "release:none",
+	})
+	if err != nil {
+		t.Fatalf("plan-auto error = %v", err)
+	}
+	assertReleaseOutput(t, output, map[string]string{
+		"release": "false",
+		"reason":  "no-release-intent",
+	})
+}
+
+func TestReleasePolicyFailsClosedForMissingIntent(t *testing.T) {
+	repo := newReleaseRepository(t)
+	output, err := runReleasePolicyPlan(t, repo, repo.head, map[string]string{
+		"PR_11_LABEL": "release:patch",
+	})
+	if err == nil || !strings.Contains(output, "pull request #10 must have exactly one release label") {
+		t.Fatalf("plan-auto error = %v, output = %q", err, output)
+	}
+}
+
+func TestReleasePolicyFailsClosedForDirectCommit(t *testing.T) {
+	repo := newReleaseRepository(t)
+	writeReleaseFile(t, repo.dir, "direct", "direct")
+	runGit(t, repo.dir, "add", "fixture")
+	runGit(t, repo.dir, "commit", "-m", "direct change without pull request")
+	directSHA := strings.TrimSpace(runGit(t, repo.dir, "rev-parse", "HEAD"))
+	runGit(t, repo.dir, "update-ref", "refs/remotes/origin/master", directSHA)
+
+	output, err := runReleasePolicyPlan(t, repo, directSHA, map[string]string{
+		"PR_10_LABEL": "release:minor",
+		"PR_11_LABEL": "release:patch",
+	})
+	if err == nil || !strings.Contains(output, "must identify exactly one pull request merged into master") {
+		t.Fatalf("plan-auto error = %v, output = %q", err, output)
+	}
+}
+
+func TestReleasePolicyHandlesCoveredAndInterruptedRuns(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		target        string
+		releaseExists bool
+		releaseDraft  bool
+		want          map[string]string
+	}{
+		{
+			name:   "newer unpublished tag is recovered",
+			target: "first",
+			want: map[string]string{
+				"release":      "true",
+				"tag":          "v1.40.0",
+				"existing_tag": "true",
+				"release_sha":  "head",
+			},
+		},
+		{
+			name:   "tag exists without release",
+			target: "head",
+			want: map[string]string{
+				"release":      "true",
+				"tag":          "v1.40.0",
+				"existing_tag": "true",
+				"level":        "resume",
+			},
+		},
+		{
+			name:         "draft release is resumed",
+			target:       "head",
+			releaseDraft: true,
+			want: map[string]string{
+				"release":      "true",
+				"tag":          "v1.40.0",
+				"existing_tag": "true",
+				"level":        "resume",
+			},
+		},
+		{
+			name:          "release already exists",
+			target:        "head",
+			releaseExists: true,
+			want: map[string]string{
+				"release": "false",
+				"reason":  "already-released",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			repo := newReleaseRepository(t)
+			runGit(t, repo.dir, "tag", "-a", "v1.40.0", "-m", "release v1.40.0", repo.head)
+			target := repo.head
+			if test.target == "first" {
+				target = repo.first
+			}
+			variables := map[string]string{
+				"PR_10_LABEL": "release:minor",
+				"PR_11_LABEL": "release:patch",
+			}
+			if test.releaseExists {
+				variables["RELEASE_EXISTS"] = "true"
+			}
+			if test.releaseDraft {
+				variables["RELEASE_DRAFT"] = "true"
+			}
+			output, err := runReleasePolicyPlan(t, repo, target, variables)
+			if err != nil {
+				t.Fatalf("plan-auto error = %v, output = %q", err, output)
+			}
+			if test.want["release_sha"] == "head" {
+				test.want["release_sha"] = repo.head
+			}
+			assertReleaseOutput(t, output, test.want)
+		})
+	}
+}
+
+func TestReleasePolicyValidatesPushedTagAgainstLabels(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		tag         string
+		wantFailure bool
+		wantMessage string
+	}{
+		{name: "expected tag", tag: "v1.40.0"},
+		{name: "unexpected tag", tag: "v1.99.0", wantFailure: true, wantMessage: "does not match expected tag v1.40.0"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			repo := newReleaseRepository(t)
+			runGit(t, repo.dir, "tag", "-a", test.tag, "-m", "release "+test.tag, repo.head)
+			output, err := runReleasePolicy(t, repo, "plan-tag", map[string]string{
+				"PR_10_LABEL": "release:minor",
+				"PR_11_LABEL": "release:patch",
+				"RELEASE_TAG": test.tag,
+			})
+			if (err != nil) != test.wantFailure {
+				t.Fatalf("plan-tag error = %v, wantFailure = %t; output: %s", err, test.wantFailure, output)
+			}
+			if test.wantMessage != "" && !strings.Contains(output, test.wantMessage) {
+				t.Fatalf("plan-tag output = %q, want %q", output, test.wantMessage)
+			}
+			if !test.wantFailure {
+				assertReleaseOutput(t, output, map[string]string{
+					"release":      "true",
+					"tag":          "v1.40.0",
+					"existing_tag": "true",
+				})
+			}
+		})
+	}
+}
+
+func TestReleasePolicyFailsClosedForAmbiguousTagState(t *testing.T) {
+	repo := newReleaseRepository(t)
+	runGit(t, repo.dir, "tag", "-a", "v1.40.0", "-m", "release v1.40.0", repo.head)
+	runGit(t, repo.dir, "tag", "-a", "v1.41.0", "-m", "release v1.41.0", repo.head)
+	output, err := runReleasePolicyPlan(t, repo, repo.head, map[string]string{
+		"PR_10_LABEL": "release:minor",
+		"PR_11_LABEL": "release:patch",
+	})
+	if err == nil || !strings.Contains(output, "multiple unpublished stable tags") {
+		t.Fatalf("plan-auto error = %v, output = %q", err, output)
+	}
+}
+
+func TestReleasePolicyFailsClosedWhenReleaseStateIsUnavailable(t *testing.T) {
+	repo := newReleaseRepository(t)
+	output, err := runReleasePolicyPlan(t, repo, repo.head, map[string]string{
+		"PR_10_LABEL":       "release:minor",
+		"PR_11_LABEL":       "release:patch",
+		"RELEASE_API_ERROR": "true",
+	})
+	if err == nil || !strings.Contains(output, "cannot determine whether GitHub Release") {
+		t.Fatalf("plan-auto error = %v, output = %q", err, output)
+	}
+}
+
+type releaseRepository struct {
+	dir   string
+	first string
+	head  string
+}
+
+func newReleaseRepository(t *testing.T) releaseRepository {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "master")
+	runGit(t, dir, "config", "user.name", "Release Test")
+	runGit(t, dir, "config", "user.email", "release@example.com")
+	writeReleaseFile(t, dir, "base", "base")
+	runGit(t, dir, "add", "fixture")
+	runGit(t, dir, "commit", "-m", "base")
+	runGit(t, dir, "tag", "-a", "v1.39.6", "-m", "release v1.39.6")
+
+	writeReleaseFile(t, dir, "feature", "feature")
+	runGit(t, dir, "add", "fixture")
+	runGit(t, dir, "commit", "-m", "feature commit without pull request suffix")
+	first := strings.TrimSpace(runGit(t, dir, "rev-parse", "HEAD"))
+
+	writeReleaseFile(t, dir, "fix", "fix")
+	runGit(t, dir, "add", "fixture")
+	runGit(t, dir, "commit", "-m", "fix commit without pull request suffix")
+	head := strings.TrimSpace(runGit(t, dir, "rev-parse", "HEAD"))
+	runGit(t, dir, "update-ref", "refs/remotes/origin/master", head)
+	return releaseRepository{dir: dir, first: first, head: head}
+}
+
+func runReleasePolicyPlan(t *testing.T, repo releaseRepository, target string, variables map[string]string) (string, error) {
+	t.Helper()
+	variables["RELEASE_TARGET_SHA"] = target
+	return runReleasePolicy(t, repo, "plan-auto", variables)
+}
+
+func runReleasePolicy(t *testing.T, repo releaseRepository, mode string, variables map[string]string) (string, error) {
+	t.Helper()
+	script := releasePolicyScript(t)
+	writeReleaseFakeGH(t, repo.dir)
+	outputPath := filepath.Join(repo.dir, "github-output")
+	command := exec.Command("bash", script, mode)
+	command.Dir = repo.dir
+	command.Env = append(os.Environ(),
+		"PATH="+repo.dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GITHUB_OUTPUT="+outputPath,
+		"GITHUB_REPOSITORY=ucloud/terraform-provider-ucloud",
+		"PR_10_SHA="+repo.first,
+		"PR_11_SHA="+repo.head,
+	)
+	for name, value := range variables {
+		command.Env = append(command.Env, name+"="+value)
+	}
+	combined, err := command.CombinedOutput()
+	outputs, readErr := os.ReadFile(outputPath)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatalf("read GitHub output: %v", readErr)
+	}
+	return string(combined) + string(outputs), err
+}
+
+func assertReleaseOutput(t *testing.T, output string, want map[string]string) {
+	t.Helper()
+	got := make(map[string]string)
+	for _, line := range strings.Split(output, "\n") {
+		if name, value, found := strings.Cut(line, "="); found {
+			got[name] = value
+		}
+	}
+	for name, value := range want {
+		if got[name] != value {
+			t.Errorf("%s = %q, want %q; output: %s", name, got[name], value, output)
+		}
+	}
+}
+
+func releasePolicyScript(t *testing.T) string {
+	t.Helper()
+	script, err := filepath.Abs("release-policy.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+func writeReleaseEvent(t *testing.T, filename string, labels []string) {
+	t.Helper()
+	payloadLabels := make([]map[string]string, 0, len(labels))
+	for _, label := range labels {
+		payloadLabels = append(payloadLabels, map[string]string{"name": label})
+	}
+	payload := map[string]interface{}{
+		"repository": map[string]string{"full_name": "ucloud/terraform-provider-ucloud"},
+		"pull_request": map[string]interface{}{
+			"head":             map[string]string{"sha": releaseHeadSHA},
+			"merge_commit_sha": releaseMergeSHA,
+			"labels":           payloadLabels,
+		},
+	}
+	contents, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filename, contents, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeReleaseFakeGH(t *testing.T, dir string) {
+	t.Helper()
+	contents := `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" != 'api' ]]; then
+  echo "unexpected gh command: $*" >&2
+  exit 2
+fi
+shift
+if [[ "${1:-}" == '--method' ]]; then
+  printf '%s\n' "api $*" >>"${RELEASE_GH_CALLS}"
+  printf '{"ok":true}\n'
+  exit 0
+fi
+endpoint="${1:-}"
+if [[ "${endpoint}" == */commits/"${PR_10_SHA:-missing}"/pulls ]]; then
+  printf '[{"number":10,"merged_at":"2026-09-08T00:00:00Z","base":{"ref":"master"}}]\n'
+  exit 0
+fi
+if [[ "${endpoint}" == */commits/"${PR_11_SHA:-missing}"/pulls ]]; then
+  printf '[{"number":11,"merged_at":"2026-09-08T00:00:00Z","base":{"ref":"master"}}]\n'
+  exit 0
+fi
+case "${endpoint}" in
+  */pulls/10) label="${PR_10_LABEL:-}" ;;
+  */pulls/11) label="${PR_11_LABEL:-}" ;;
+	*/releases/tags/*)
+    tag="${endpoint##*/}"
+    if [[ "${RELEASE_API_ERROR:-false}" == 'true' ]]; then
+      echo 'gh: HTTP 503: service unavailable' >&2
+      exit 1
+    fi
+    if [[ "${tag}" == "${PUBLISHED_TAG:-v1.39.6}" || ("${RELEASE_EXISTS:-false}" == 'true' && "${tag}" == 'v1.40.0') ]]; then
+      printf '{"tag_name":"%s","draft":false}\n' "${tag}"
+      exit 0
+    fi
+    if [[ "${RELEASE_DRAFT:-false}" == 'true' && "${tag}" == 'v1.40.0' ]]; then
+      printf '{"tag_name":"%s","draft":true}\n' "${tag}"
+      exit 0
+    fi
+    echo 'gh: Not Found (HTTP 404)' >&2
+    exit 1
+    ;;
+  */commits/*/pulls) printf '[]\n'; exit 0 ;;
+  *) echo "unexpected gh api endpoint: ${endpoint}" >&2; exit 2 ;;
+esac
+if [[ -n "${label}" ]]; then
+  printf '{"merged_at":"2026-09-08T00:00:00Z","base":{"ref":"master"},"labels":[{"name":"%s"}]}\n' "${label}"
+else
+  printf '{"merged_at":"2026-09-08T00:00:00Z","base":{"ref":"master"},"labels":[]}\n'
+fi
+`
+	filename := filepath.Join(dir, "gh")
+	if err := os.WriteFile(filename, []byte(contents), 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeReleaseFile(t *testing.T, dir, value, message string) {
+	t.Helper()
+	filename := filepath.Join(dir, "fixture")
+	if err := os.WriteFile(filename, []byte(value+"\n"), 0644); err != nil {
+		t.Fatalf("write %s: %v", message, err)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = dir
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return fmt.Sprintf("%s", output)
+}


### PR DESCRIPTION
## Summary

- require exactly one release intent label on every PR
- release automatically after successful master CI
- calculate SemVer from merged PR labels and recover interrupted draft releases
- pin release actions and GoReleaser versions

## Verification

- `make test`
- `make compat`
- `make vet`
- Actionlint and ShellCheck
- `goreleaser v2.18.1 check`