### PR TITLE
fix: 无发布标签时默认小版本发版

### DIFF
--- a/.github/workflows/release-intent.yml
+++ b/.github/workflows/release-intent.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - name: Require one release label
+      - name: Resolve release intent (default minor)
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: bash scripts/release-policy.sh check-pr

--- a/scripts/release-policy.sh
+++ b/scripts/release-policy.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 readonly RELEASE_LABEL_PREFIX='release:'
+readonly DEFAULT_RELEASE_LEVEL='minor'
+readonly DEFAULT_RELEASE_LABEL="${RELEASE_LABEL_PREFIX}${DEFAULT_RELEASE_LEVEL}"
 readonly RELEASE_STATUS_CONTEXT='release-intent'
 readonly STABLE_TAG_PATTERN='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
 
@@ -80,7 +82,7 @@ fail_pull_request_check() {
   local merge_sha="$3"
   local message="$4"
 
-  if ! set_pull_request_statuses "${repository}" "${head_sha}" "${merge_sha}" failure 'select exactly one supported release label'; then
+  if ! set_pull_request_statuses "${repository}" "${head_sha}" "${merge_sha}" failure 'select one supported release label or leave it unset for default minor'; then
     printf 'release policy: failed to publish release-intent failure status\n' >&2
   fi
   die "${message}"
@@ -113,12 +115,19 @@ check_pull_request() {
   release_labels="$(jq -c '[.pull_request.labels[]?.name | strings | select(startswith("release:"))]' "${GITHUB_EVENT_PATH}")" ||
     fail_pull_request_check "${repository}" "${head_sha}" "${merge_sha}" 'cannot read pull request labels'
   label_count="$(jq -r 'length' <<<"${release_labels}")"
-  if [[ "${label_count}" != '1' ]]; then
+  if ((label_count > 1)); then
     fail_pull_request_check "${repository}" "${head_sha}" "${merge_sha}" \
-      "pull request must have exactly one release label; found ${label_count}"
+      "pull request must have exactly one release label or leave it unset for default minor; found ${label_count}"
   fi
 
-  release_label="$(jq -r '.[0]' <<<"${release_labels}")"
+  local release_description
+  if ((label_count == 0)); then
+    release_label="${DEFAULT_RELEASE_LABEL}"
+    release_description="release intent defaults to ${DEFAULT_RELEASE_LEVEL}"
+  else
+    release_label="$(jq -r '.[0]' <<<"${release_labels}")"
+    release_description="release intent is ${release_label#"${RELEASE_LABEL_PREFIX}"}"
+  fi
   case "${release_label}" in
     release:major | release:minor | release:patch | release:none) ;;
     *)
@@ -128,7 +137,7 @@ check_pull_request() {
   esac
 
   set_pull_request_statuses "${repository}" "${head_sha}" "${merge_sha}" success \
-    "release intent is ${release_label#"${RELEASE_LABEL_PREFIX}"}"
+    "${release_description}"
   printf 'release policy: %s\n' "${release_label}"
 }
 
@@ -234,8 +243,12 @@ release_level_for_pull_request() {
 
   label_count="$(jq '[.labels[]?.name | strings | select(startswith("release:"))] | length' <<<"${metadata}")" ||
     die "cannot read labels for pull request #${pull_request}"
-  if [[ "${label_count}" != '1' ]]; then
-    die "pull request #${pull_request} must have exactly one release label; found ${label_count}"
+  if ((label_count > 1)); then
+    die "pull request #${pull_request} must have exactly one release label or leave it unset; found ${label_count}"
+  fi
+  if ((label_count == 0)); then
+    printf '%s\n' "${DEFAULT_RELEASE_LEVEL}"
+    return 0
   fi
   release_label="$(jq -r '[.labels[]?.name | strings | select(startswith("release:"))][0]' <<<"${metadata}")"
   case "${release_label}" in

--- a/scripts/release_policy_test.go
+++ b/scripts/release_policy_test.go
@@ -18,14 +18,16 @@ const (
 func TestReleasePolicyChecksPullRequestLabels(t *testing.T) {
 	script := releasePolicyScript(t)
 	for _, test := range []struct {
-		name        string
-		labels      []string
-		wantFailure bool
-		wantMessage string
-		wantState   string
+		name            string
+		labels          []string
+		wantFailure     bool
+		wantMessage     string
+		wantDescription string
+		wantState       string
 	}{
 		{name: "one supported label", labels: []string{"release:minor", "uhost"}, wantState: "success"},
-		{name: "missing release label", labels: []string{"uhost"}, wantFailure: true, wantMessage: "exactly one release label", wantState: "failure"},
+		{name: "missing release label defaults to minor", labels: []string{"uhost"}, wantDescription: "description=release intent defaults to minor", wantState: "success"},
+		{name: "explicit none", labels: []string{"release:none"}, wantState: "success"},
 		{name: "multiple release labels", labels: []string{"release:minor", "release:patch"}, wantFailure: true, wantMessage: "exactly one release label", wantState: "failure"},
 		{name: "unsupported release label", labels: []string{"release:preview"}, wantFailure: true, wantMessage: "unsupported release label", wantState: "failure"},
 	} {
@@ -61,6 +63,9 @@ func TestReleasePolicyChecksPullRequestLabels(t *testing.T) {
 			}
 			if count := strings.Count(got, "state="+test.wantState); count != 2 {
 				t.Fatalf("%s status count = %d, want 2; calls: %s", test.wantState, count, got)
+			}
+			if test.wantDescription != "" && !strings.Contains(got, test.wantDescription) {
+				t.Fatalf("status calls = %q, want description %q", got, test.wantDescription)
 			}
 			if strings.Count(got, "context=release-intent") != 4 {
 				t.Fatalf("release-intent status count is wrong; calls: %s", got)
@@ -105,14 +110,23 @@ func TestReleasePolicySkipsChangesMarkedNone(t *testing.T) {
 	})
 }
 
-func TestReleasePolicyFailsClosedForMissingIntent(t *testing.T) {
+func TestReleasePolicyDefaultsMissingIntentToMinor(t *testing.T) {
 	repo := newReleaseRepository(t)
 	output, err := runReleasePolicyPlan(t, repo, repo.head, map[string]string{
 		"PR_11_LABEL": "release:patch",
 	})
-	if err == nil || !strings.Contains(output, "pull request #10 must have exactly one release label") {
+	if err != nil {
 		t.Fatalf("plan-auto error = %v, output = %q", err, output)
 	}
+	assertReleaseOutput(t, output, map[string]string{
+		"release":       "true",
+		"tag":           "v1.40.0",
+		"previous_tag":  "v1.39.6",
+		"level":         "minor",
+		"pull_requests": "10,11",
+		"existing_tag":  "false",
+		"release_sha":   repo.head,
+	})
 }
 
 func TestReleasePolicyFailsClosedForDirectCommit(t *testing.T) {


### PR DESCRIPTION
## 变更

- 没有 `release:*` 标签时，发布意图默认按 `minor` 处理。
- 只有显式 `release:none` 才跳过版本创建；显式 `release:major`、`release:minor`、`release:patch` 保持原有行为。
- PR 检查状态明确显示默认的 minor 意图；多标签和不支持的标签仍然失败。

## 验证

- `go test ./scripts ./internal/productownership -count=1`
- `make compat`
- `make vet`
- `make test`
- Shell 语法和 `git diff --check`
